### PR TITLE
ci: adding dod cas so we can connect to artifactory

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -18,6 +18,7 @@ jobs:
           C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
 
         run: |
+          sudo sh scripts/add-dod-cas.sh
           docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
           docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG . --build-arg BUILD=$IMAGE_TAG
           docker push $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG

--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Import DoD root certificates into linux CA store
+
+
+    # Location of bundle from DISA site
+    bundle=https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/certificates_pkcs7_DoD.zip
+
+    # Extract the bundle
+    cd /usr/local/share/ca-certificates
+    wget $bundle
+    unzip certificates_pkcs7_DoD.zip
+
+    # Convert the PKCS#7 bundle into individual PEM files
+    openssl pkcs7 -print_certs -in Certificates_PKCS7_v5.9_DoD/*.pem.p7b |
+        awk 'BEGIN {c=0} /subject=/ {c++} {print > "cert." c ".pem"}'
+
+    # Rename the files based on the CA name
+    for i in *.pem; do
+        name=$(openssl x509 -noout -subject -in $i |
+               awk -F '(=|= )' '{gsub(/ /, "_", $NF); print $NF}'
+        )
+        mv $i ${name}.crt
+    done
+
+    # update certificate stores
+    update-ca-certificates
+
+    rm certificates_pkcs7_DoD.zip


### PR DESCRIPTION
## Description 

Right now we can't connect to artifactory because of the DoD's self-signed certs. I believe this should add the CA's so that we can connect to artifactory and upload the docker image.