### PR TITLE
chore: fix typo in URL

### DIFF
--- a/scripts/add-rds-cas.sh
+++ b/scripts/add-rds-cas.sh
@@ -3,6 +3,8 @@
 
   comcert=https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
   govcert=https://s3-us-gov-west-1.amazonaws.com/rds-downloads/rds-combined-ca-us-gov-bundle.pem
-  
+  uswestgov=https://truststore.pki.us-gov-west-1.rds.amazonaws.com/us-gov-east-1/us-gov-west-1-bundle.pem
+
   wget $comcert
   wget $govcert
+  wget $uswestgov

--- a/scripts/add-rds-cas.sh
+++ b/scripts/add-rds-cas.sh
@@ -3,7 +3,7 @@
 
   comcert=https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
   govcert=https://s3-us-gov-west-1.amazonaws.com/rds-downloads/rds-combined-ca-us-gov-bundle.pem
-  uswestgov=https://truststore.pki.us-gov-west-1.rds.amazonaws.com/us-gov-east-1/us-gov-west-1-bundle.pem
+  uswestgov=https://truststore.pki.us-gov-west-1.rds.amazonaws.com/us-gov-west-1/us-gov-west-1-bundle.pem
 
   wget $comcert
   wget $govcert


### PR DESCRIPTION
Bad copy/paste. Fixes the path so it'll download the cert.