### PR TITLE
feat: Add category field to article schema

### DIFF
--- a/e2e/database/seed.js
+++ b/e2e/database/seed.js
@@ -106,6 +106,8 @@ ALTER TABLE "public"."User" ADD FOREIGN KEY ("updatedBy") REFERENCES "public"."U
 
   await client.query(`DROP TYPE IF EXISTS "public"."ArticleStatusType";`)
 
+  await client.query(`DROP TYPE IF EXISTS "public"."ArticleCategoryType";`)
+
   await client.query(
     `CREATE TYPE "public"."ArticleStatusType" AS ENUM ('Archived', 'Published', 'Draft');`
   )

--- a/e2e/database/seed.js
+++ b/e2e/database/seed.js
@@ -110,6 +110,10 @@ ALTER TABLE "public"."User" ADD FOREIGN KEY ("updatedBy") REFERENCES "public"."U
     `CREATE TYPE "public"."ArticleStatusType" AS ENUM ('Archived', 'Published', 'Draft');`
   )
 
+  await client.query(
+    `CREATE TYPE "public"."ArticleCategoryType" AS ENUM ('InternalNews', 'ORBITBlog')`
+  )
+
   await client.query(`CREATE TABLE "public"."Article" (
     "id" text NOT NULL,
     "slug" text NOT NULL DEFAULT ''::text,
@@ -117,6 +121,7 @@ ALTER TABLE "public"."User" ADD FOREIGN KEY ("updatedBy") REFERENCES "public"."U
     "preview" text NOT NULL DEFAULT ''::text,
     "body" jsonb NOT NULL DEFAULT '[{"type": "paragraph", "children": [{"text": ""}]}]'::jsonb,
     "status" "public"."ArticleStatusType" NOT NULL DEFAULT 'Draft'::"ArticleStatusType",
+    "category" "public"."ArticleCategoryType" NOT NULL,
     "keywords" text NOT NULL DEFAULT ''::text,
     "byline" jsonb NOT NULL DEFAULT '[{"name": ""}]'::jsonb,
     "location" jsonb NOT NULL DEFAULT '[{"name": ""}]'::jsonb,

--- a/e2e/tests/article.spec.ts
+++ b/e2e/tests/article.spec.ts
@@ -48,6 +48,11 @@ describe('Articles', () => {
     ])
 
     await page.locator('button:has-text("Create Article")').click()
+
+    await page.locator('label[for="category"]').click()
+    await page.keyboard.type('O')
+    await page.keyboard.press('Enter')
+
     await page.locator('#slug').fill('test-article-for-playwright')
     await page.locator('#title').fill('My Test Article')
     await page.locator('#preview').fill('This is my test article.')

--- a/migrations/20220527214221_add_article_category/migration.sql
+++ b/migrations/20220527214221_add_article_category/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `category` to the `Article` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "ArticleCategoryType" AS ENUM ('InternalNews', 'ORBITBlog');
+
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN     "category" "ArticleCategoryType" NOT NULL;

--- a/schema.graphql
+++ b/schema.graphql
@@ -681,6 +681,7 @@ input TagCreateInput {
 
 type Article {
   id: ID!
+  category: ArticleCategoryType
   status: ArticleStatusType
   slug: String
   title: String
@@ -711,6 +712,11 @@ type Article {
   createdAt: DateTime
 }
 
+enum ArticleCategoryType {
+  InternalNews
+  ORBITBlog
+}
+
 enum ArticleStatusType {
   Draft
   Published
@@ -731,6 +737,7 @@ input ArticleWhereInput {
   OR: [ArticleWhereInput!]
   NOT: [ArticleWhereInput!]
   id: IDFilter
+  category: ArticleCategoryTypeNullableFilter
   status: ArticleStatusTypeNullableFilter
   slug: StringFilter
   title: StringFilter
@@ -746,6 +753,13 @@ input ArticleWhereInput {
   createdBy: UserWhereInput
   updatedAt: DateTimeNullableFilter
   createdAt: DateTimeNullableFilter
+}
+
+input ArticleCategoryTypeNullableFilter {
+  equals: ArticleCategoryType
+  in: [ArticleCategoryType!]
+  notIn: [ArticleCategoryType!]
+  not: ArticleCategoryTypeNullableFilter
 }
 
 input ArticleStatusTypeNullableFilter {
@@ -769,6 +783,7 @@ input TagManyRelationFilter {
 
 input ArticleOrderByInput {
   id: OrderDirection
+  category: OrderDirection
   status: OrderDirection
   slug: OrderDirection
   title: OrderDirection
@@ -781,6 +796,7 @@ input ArticleOrderByInput {
 }
 
 input ArticleUpdateInput {
+  category: ArticleCategoryType
   status: ArticleStatusType
   slug: String
   title: String
@@ -827,6 +843,7 @@ input ArticleUpdateArgs {
 }
 
 input ArticleCreateInput {
+  category: ArticleCategoryType
   status: ArticleStatusType
   slug: String
   title: String

--- a/schema.prisma
+++ b/schema.prisma
@@ -160,27 +160,28 @@ model Tag {
 }
 
 model Article {
-  id            String            @id @default(cuid())
-  status        ArticleStatusType @default(Draft)
-  slug          String            @unique @default("")
-  title         String            @default("")
-  preview       String            @default("")
-  body          Json              @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
-  keywords      String            @default("")
+  id            String              @id @default(cuid())
+  category      ArticleCategoryType
+  status        ArticleStatusType   @default(Draft)
+  slug          String              @unique @default("")
+  title         String              @default("")
+  preview       String              @default("")
+  body          Json                @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
+  keywords      String              @default("")
   publishedDate DateTime?
   archivedDate  DateTime?
-  byline        Byline?           @relation("Article_byline", fields: [bylineId], references: [id])
-  bylineId      String?           @map("byline")
-  location      Location?         @relation("Article_location", fields: [locationId], references: [id])
-  locationId    String?           @map("location")
-  labels        Label[]           @relation("Article_labels")
-  tags          Tag[]             @relation("Article_tags")
-  updatedBy     User?             @relation("Article_updatedBy", fields: [updatedById], references: [id])
-  updatedById   String?           @map("updatedBy")
-  createdBy     User?             @relation("Article_createdBy", fields: [createdById], references: [id])
-  createdById   String?           @map("createdBy")
-  updatedAt     DateTime?         @updatedAt
-  createdAt     DateTime?         @default(now())
+  byline        Byline?             @relation("Article_byline", fields: [bylineId], references: [id])
+  bylineId      String?             @map("byline")
+  location      Location?           @relation("Article_location", fields: [locationId], references: [id])
+  locationId    String?             @map("location")
+  labels        Label[]             @relation("Article_labels")
+  tags          Tag[]               @relation("Article_tags")
+  updatedBy     User?               @relation("Article_updatedBy", fields: [updatedById], references: [id])
+  updatedById   String?             @map("updatedBy")
+  createdBy     User?               @relation("Article_createdBy", fields: [createdById], references: [id])
+  createdById   String?             @map("createdBy")
+  updatedAt     DateTime?           @updatedAt
+  createdAt     DateTime?           @default(now())
 
   @@index([bylineId])
   @@index([locationId])
@@ -192,6 +193,11 @@ enum UserRoleType {
   User
   Author
   Manager
+}
+
+enum ArticleCategoryType {
+  InternalNews
+  ORBITBlog
 }
 
 enum ArticleStatusType {

--- a/src/lists/Article.test.ts
+++ b/src/lists/Article.test.ts
@@ -16,12 +16,13 @@ describe('Article schema', () => {
   let managerArticle: Record<string, any>
   let adminArticle: Record<string, any>
 
-  const articleQuery = `id slug title preview status`
+  const articleQuery = `id slug title preview status category`
 
   const testArticleData = {
     slug: 'test-article',
     title: 'Test Article',
     preview: 'This article is a test',
+    category: 'InternalNews',
   }
 
   const resetArticles = async () => {
@@ -72,6 +73,7 @@ describe('Article schema', () => {
           userContext.query.Article.createOne({
             data: {
               title: 'User Collection',
+              category: 'InternalNews',
             },
             query: articleQuery,
           })
@@ -119,6 +121,7 @@ describe('Article schema', () => {
           slug: 'author-article',
           title: 'Author Article',
           preview: 'This article is written by an author',
+          category: 'InternalNews',
         }
 
         authorArticle = await authorContext.query.Article.createOne({
@@ -220,6 +223,7 @@ describe('Article schema', () => {
           slug: 'manager-article',
           title: 'Manager Article',
           preview: 'This article is written by a manager',
+          category: 'InternalNews',
         }
 
         managerArticle = await managerContext.query.Article.createOne({
@@ -356,6 +360,7 @@ describe('Article schema', () => {
           slug: 'admin-article',
           title: 'Admin Article',
           preview: 'This article is written by an admin',
+          category: 'InternalNews',
         }
 
         adminArticle = await adminContext.query.Article.createOne({
@@ -488,11 +493,25 @@ describe('Article schema', () => {
       await resetArticles()
     })
 
+    it('category is required', async () => {
+      const testAuthorArticle = {
+        title: 'Author Article',
+      }
+
+      expect(
+        authorContext.query.Article.createOne({
+          data: testAuthorArticle,
+          query: articleQuery,
+        })
+      ).rejects.toThrow(/You provided invalid data for this operation./)
+    })
+
     it('must enter a valid slug', async () => {
       const testAuthorArticle = {
         slug: 'Invalid slug',
         title: 'Author Article',
         preview: 'This article is written by an author',
+        category: 'InternalNews',
       }
 
       expect(
@@ -508,6 +527,7 @@ describe('Article schema', () => {
         data: {
           slug: 'article-1',
           title: 'First article',
+          category: 'InternalNews',
         },
       })
 
@@ -516,6 +536,7 @@ describe('Article schema', () => {
           data: {
             slug: 'article-1',
             title: 'Second article',
+            category: 'InternalNews',
           },
         })
       ).rejects.toThrow(/Unique constraint failed/)
@@ -525,6 +546,7 @@ describe('Article schema', () => {
       const data = await authorContext.query.Article.createOne({
         data: {
           title: 'My Article With No Slug',
+          category: 'InternalNews',
         },
         query: articleQuery,
       })
@@ -536,6 +558,7 @@ describe('Article schema', () => {
       const article = await authorContext.query.Article.createOne({
         data: {
           title: 'An article needs a slug',
+          category: 'InternalNews',
         },
         query: articleQuery,
       })

--- a/src/lists/Article.ts
+++ b/src/lists/Article.ts
@@ -19,6 +19,11 @@ import { slugify } from '../util/formatting'
 const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const SLUG_MAX = 1000
 
+const ARTICLE_CATEGORIES = {
+  INTERNAL_NEWS: 'InternalNews',
+  ORBIT_BLOG: 'ORBITBlog',
+} as const
+
 const Article: Lists.Article = list(
   withTracking({
     access: {
@@ -48,6 +53,20 @@ const Article: Lists.Article = list(
     },
 
     fields: {
+      category: select({
+        type: 'enum',
+        options: (
+          Object.keys(ARTICLE_CATEGORIES) as Array<
+            keyof typeof ARTICLE_CATEGORIES
+          >
+        ).map((r) => ({
+          label: ARTICLE_CATEGORIES[r],
+          value: ARTICLE_CATEGORIES[r],
+        })),
+        validation: {
+          isRequired: true,
+        },
+      }),
       status: select({
         type: 'enum',
         options: (


### PR DESCRIPTION
# SC-563

## Proposed changes

This PR adds a `category` field to the article schema, which is required select from hardcoded enums. This field is for categorizing article content at a high level to determine where on the portal it should appear. Accepted values are: `InternalNews, ORBITBlog` (more can be added).

---

## Reviewer notes

Do you have any feedback re: the category names, or other categories that should be added?

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [ ] Created/modified automated unit tests in Jest
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
