### PR TITLE
fix: Allow CMS authors & managers to view other users

### DIFF
--- a/src/lists/User.ts
+++ b/src/lists/User.ts
@@ -8,6 +8,7 @@ import {
   isAdmin,
   isAdminOrSelf,
   editReadAdminUI,
+  userQueryFilter,
 } from '../util/access'
 import { withTracking } from '../util/tracking'
 
@@ -22,7 +23,7 @@ const User: Lists.User = list(
         delete: () => false,
       },
       filter: {
-        query: isAdminOrSelf,
+        query: userQueryFilter,
         update: isAdminOrSelf,
       },
     },

--- a/src/lists/User.ts
+++ b/src/lists/User.ts
@@ -9,6 +9,7 @@ import {
   isAdminOrSelf,
   editReadAdminUI,
   userQueryFilter,
+  userItemView,
 } from '../util/access'
 import { withTracking } from '../util/tracking'
 
@@ -35,6 +36,9 @@ const User: Lists.User = list(
       isHidden: false, // TODO - only show complete UI to admin
       hideCreate: true,
       hideDelete: true,
+      itemView: {
+        defaultFieldMode: userItemView,
+      },
       listView: {
         initialColumns: [
           'userId',

--- a/src/util/access.test.ts
+++ b/src/util/access.test.ts
@@ -10,6 +10,7 @@ import {
   isAdminOrSelf,
   showHideAdminUI,
   editReadAdminUI,
+  userQueryFilter,
   canCreateArticle,
   canUpdateDeleteArticle,
   canPublishArchiveArticle,
@@ -90,6 +91,39 @@ describe('editReadAdminUI', () => {
 
   it('returns read if there is no logged in user', () => {
     expect(editReadAdminUI({})).toBe('read')
+  })
+})
+
+describe('userQueryFilter', () => {
+  it('returns true if the logged in user is an admin', () => {
+    expect(
+      userQueryFilter({
+        session: testAdminSession,
+      })
+    ).toBe(true)
+  })
+
+  it('returns true if the logged in user is an author', () => {
+    expect(userQueryFilter({ session: testAuthorSession })).toBe(true)
+  })
+  it('returns true if the logged in user is a manager', () => {
+    expect(userQueryFilter({ session: testManagerSession })).toBe(true)
+  })
+
+  it('returns a filter on the logged in userId if not an admin, author, or manager', () => {
+    expect(
+      userQueryFilter({
+        session: testUserSession,
+      })
+    ).toEqual({
+      userId: {
+        equals: testUserSession.userId,
+      },
+    })
+  })
+
+  it('returns false if there is no logged in user', () => {
+    expect(userQueryFilter({})).toBe(false)
   })
 })
 

--- a/src/util/access.test.ts
+++ b/src/util/access.test.ts
@@ -11,6 +11,7 @@ import {
   showHideAdminUI,
   editReadAdminUI,
   userQueryFilter,
+  userItemView,
   canCreateArticle,
   canUpdateDeleteArticle,
   canPublishArchiveArticle,
@@ -124,6 +125,30 @@ describe('userQueryFilter', () => {
 
   it('returns false if there is no logged in user', () => {
     expect(userQueryFilter({})).toBe(false)
+  })
+})
+
+describe('userItemView', () => {
+  it('returns edit if the logged in user is an admin', () => {
+    expect(userItemView({ session: testAdminSession })).toBe('edit')
+  })
+
+  it('returns edit if the logged in user is the user', () => {
+    expect(
+      userItemView({
+        session: testAuthorSession,
+        item: { id: testAuthorSession.id },
+      })
+    ).toBe('edit')
+  })
+
+  it('returns read if the logged in user is NOT the user', () => {
+    expect(
+      userItemView({
+        session: testAuthorSession,
+        item: { id: testAdminSession.id },
+      })
+    ).toBe('read')
   })
 })
 

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -83,6 +83,24 @@ export const showHideAdminUI: CreateViewFn = ({ session }) =>
 export const editReadAdminUI: ItemViewFn = ({ session }) =>
   session?.isAdmin ? 'edit' : 'read'
 
+/** User helpers */
+export const userQueryFilter: OperationFilterFn = ({ session }) => {
+  // if the user is an Admin, they can access all the users
+  if (session?.isAdmin) return true
+
+  if (!session) return false
+
+  // CMS roles can view other users
+  if (
+    session?.role === USER_ROLES.AUTHOR ||
+    session?.role === USER_ROLES.MANAGER
+  )
+    return true
+
+  // otherwise, only allow access to themself
+  return { userId: { equals: session?.userId } }
+}
+
 /** Article helpers */
 export const canCreateArticle: OperationAccessFn = ({ session }) => {
   return (

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -101,6 +101,16 @@ export const userQueryFilter: OperationFilterFn = ({ session }) => {
   return { userId: { equals: session?.userId } }
 }
 
+export const userItemView: ItemViewFn = ({ session, item }) => {
+  // Admin can edit all users
+  if (session?.isAdmin) return 'edit'
+
+  // Everyone else can only edit themselves
+  if (item?.id === session?.itemId) return 'edit'
+
+  return 'read'
+}
+
 /** Article helpers */
 export const canCreateArticle: OperationAccessFn = ({ session }) => {
   return (


### PR DESCRIPTION
# SC-558

## Proposed changes

This fixes an issue where non-admin users can only view themselves, which results in Authors & Managers not being able to see what user created or modified other resources such as Articles. This PR modifies permissions to allow users with the Author or Manager role to query (read) other users -- but still can only edit themselves.

---

## Reviewer notes

Test cases:
- Admin users should be able to view and edit all other users
- Users with the Author or Manager role should be able to view all other users (but only edit themselves), _including_ the user who created or updated another object such as an Article
- Users with the User role (default) should still not be able to view any users other than themselves
* Example: log in as a Manager user and create an Article. Then log in as an Author user and view the article, verifying you can view the name of the Manager user who created it.

---

## Code review steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [x] Created/modified automated unit tests in Jest

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed