### PR TITLE
dev: Implement search resolver

### DIFF
--- a/keystone.ts
+++ b/keystone.ts
@@ -4,15 +4,18 @@ import { config } from '@keystone-6/core'
 import { lists } from './src/schema'
 import { withSharedAuth } from './src/lib/auth'
 import { getAbsoluteUrl } from './src/util/getAbsoluteUrl'
+import { SearchSchema } from './src/lib/search'
 
 export default withSharedAuth(
   config({
+    extendGraphqlSchema: SearchSchema,
     lists,
     db: {
       provider: 'postgresql',
       url: `${process.env.DATABASE_URL}` || '',
       enableLogging: true,
       useMigrations: true,
+      prismaPreviewFeatures: ['fullTextSearch'],
     },
     ui: {
       publicPages: ['/api/sysinfo', '/no-access'],

--- a/keystone.ts
+++ b/keystone.ts
@@ -4,11 +4,11 @@ import { config } from '@keystone-6/core'
 import { lists } from './src/schema'
 import { withSharedAuth } from './src/lib/auth'
 import { getAbsoluteUrl } from './src/util/getAbsoluteUrl'
-import { SearchSchema } from './src/lib/search'
+import { extendGraphqlSchema } from './src/lib/schema'
 
 export default withSharedAuth(
   config({
-    extendGraphqlSchema: SearchSchema,
+    extendGraphqlSchema,
     lists,
     db: {
       provider: 'postgresql',

--- a/schema.graphql
+++ b/schema.graphql
@@ -93,6 +93,7 @@ enum SearchResultType {
 }
 
 interface SearchResultItem {
+  id: String!
   title: String!
   preview: String!
   type: SearchResultType!
@@ -100,6 +101,7 @@ interface SearchResultItem {
 }
 
 type BookmarkResult implements SearchResultItem {
+  id: String!
   title: String!
   preview: String!
   type: SearchResultType!
@@ -107,6 +109,7 @@ type BookmarkResult implements SearchResultItem {
 }
 
 type ArticleResult implements SearchResultItem {
+  id: String!
   title: String!
   preview: String!
   type: SearchResultType!

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,9 +3,9 @@
 
 type Query {
   """
-   Authenticated Item
+   Search
   """
-  authenticatedItem: AuthenticatedItem
+  search(query: String!): [SearchResultItem]
   events(
     where: EventWhereInput! = {}
     orderBy: [EventOrderByInput!]! = []
@@ -81,7 +81,17 @@ type Query {
   keystone: KeystoneMeta!
 }
 
-union AuthenticatedItem = User
+enum SearchResultItemType {
+  Article
+  Bookmark
+}
+
+type SearchResultItem {
+  type: SearchResultItemType
+  title: String!
+  url: String!
+  description: String!
+}
 
 type Event {
   id: ID!

--- a/schema.graphql
+++ b/schema.graphql
@@ -2,14 +2,7 @@
 # Modify your Keystone config when you want to change this.
 
 type Query {
-  """
-  Search
-  """
   search(query: String!): [SearchResultItem]
-
-  """
-  Authenticated Item
-  """
   authenticatedItem: AuthenticatedItem
   events(
     where: EventWhereInput! = {}
@@ -86,16 +79,32 @@ type Query {
   keystone: KeystoneMeta!
 }
 
-enum SearchResultItemType {
+enum SearchResultType {
   Article
   Bookmark
 }
 
-type SearchResultItem {
-  type: SearchResultItemType
+interface SearchResultItem {
   title: String!
-  url: String!
-  description: String!
+  preview: String!
+  type: SearchResultType!
+  permalink: String!
+}
+
+type BookmarkResult implements SearchResultItem {
+  title: String!
+  preview: String!
+  type: SearchResultType!
+  permalink: String!
+}
+
+type ArticleResult implements SearchResultItem {
+  title: String!
+  preview: String!
+  type: SearchResultType!
+  permalink: String!
+  date: String!
+  labels: [Label]
 }
 
 union AuthenticatedItem = User

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,9 +3,14 @@
 
 type Query {
   """
-   Search
+  Search
   """
   search(query: String!): [SearchResultItem]
+
+  """
+  Authenticated Item
+  """
+  authenticatedItem: AuthenticatedItem
   events(
     where: EventWhereInput! = {}
     orderBy: [EventOrderByInput!]! = []
@@ -92,6 +97,8 @@ type SearchResultItem {
   url: String!
   description: String!
 }
+
+union AuthenticatedItem = User
 
 type Event {
   id: ID!

--- a/schema.prisma
+++ b/schema.prisma
@@ -7,8 +7,9 @@ datasource postgresql {
 }
 
 generator client {
-  provider = "prisma-client-js"
-  output   = "node_modules/.prisma/client"
+  provider        = "prisma-client-js"
+  output          = "node_modules/.prisma/client"
+  previewFeatures = ["fullTextSearch"]
 }
 
 model Event {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,4 @@
 import type { KeystoneConfig, SessionStrategy } from '@keystone-6/core/types'
-import { graphQLSchemaExtension } from '@keystone-6/core'
-
-import type { Context } from '.keystone/types'
 
 import type {
   SessionData,
@@ -118,38 +115,6 @@ const withAuthData = (
   }
 }
 
-const extendGraphqlSchema = graphQLSchemaExtension<Context>({
-  typeDefs: `
-     type Query {
-      """ Authenticated Item """
-      authenticatedItem: AuthenticatedItem
-    }
-
-    union AuthenticatedItem = User
-  `,
-  resolvers: {
-    Query: {
-      authenticatedItem: async (root, args, { session, db }) => {
-        if (typeof session?.userId === 'string') {
-          const user = await db.User.findOne({
-            where: { userId: session.userId },
-          })
-
-          return {
-            __typename: 'User',
-            listKey: 'User',
-            label: user.userId,
-            itemId: user.id,
-            ...user,
-          }
-        }
-
-        return null
-      },
-    },
-  },
-})
-
 export const withSharedAuth = (
   keystoneConfig: KeystoneConfig
 ): KeystoneConfig => {
@@ -158,6 +123,5 @@ export const withSharedAuth = (
   return {
     ...keystoneConfig,
     session: sessionWithUser,
-    ...extendGraphqlSchema,
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -123,11 +123,9 @@ const extendGraphqlSchema = graphQLSchemaExtension<Context>({
      type Query {
       """ Authenticated Item """
       authenticatedItem: AuthenticatedItem
-      
     }
 
     union AuthenticatedItem = User
-
   `,
   resolvers: {
     Query: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -120,12 +120,14 @@ const withAuthData = (
 
 const extendGraphqlSchema = graphQLSchemaExtension<Context>({
   typeDefs: `
-    type Query {
+     type Query {
       """ Authenticated Item """
       authenticatedItem: AuthenticatedItem
+      
     }
 
     union AuthenticatedItem = User
+
   `,
   resolvers: {
     Query: {
@@ -158,6 +160,6 @@ export const withSharedAuth = (
   return {
     ...keystoneConfig,
     session: sessionWithUser,
-    extendGraphqlSchema,
+    ...extendGraphqlSchema,
   }
 }

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -35,6 +35,7 @@ describe('Search Resolver', () => {
   query Search($query: String!) {
     search(query: $query) {
       __typename
+      id
       title
       preview
       permalink

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -6,10 +6,11 @@ import {
   searchTermArticleData,
   surf,
   orders,
+  testArticles,
+  testBookmarks,
 } from '../testData'
 
 import { configTestEnv, TestEnvWithSessions } from '../testHelpers'
-import { testArticles, testBookmarks } from '../testData'
 
 let testEnv: TestEnvWithSessions
 let graphQLRequest: GraphQLRequest

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -1,4 +1,5 @@
 import { GraphQLRequest } from '@keystone-6/core/testing'
+import { KeystoneContext } from '@keystone-6/core/types'
 import {
   myVector,
   publishedArticleData,
@@ -8,13 +9,19 @@ import {
 } from '../testData'
 
 import { configTestEnv, TestEnvWithSessions } from '../testHelpers'
+import { testArticles, testBookmarks } from '../testData'
 
 let testEnv: TestEnvWithSessions
 let graphQLRequest: GraphQLRequest
+let sudoContext: KeystoneContext
 
 beforeAll(async () => {
   testEnv = await configTestEnv()
   graphQLRequest = testEnv.testArgs.graphQLRequest
+  sudoContext = testEnv.sudoContext
+
+  await sudoContext.query.Article.createMany({ data: testArticles })
+  await sudoContext.query.Bookmark.createMany({ data: testBookmarks })
 })
 
 afterAll(async () => {

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -1,0 +1,216 @@
+import { GraphQLRequest } from '@keystone-6/core/testing'
+import {
+  myVector,
+  publishedArticleData,
+  searchTermArticleData,
+  surf,
+  orders,
+} from '../testData'
+
+import { configTestEnv, TestEnvWithSessions } from '../testHelpers'
+
+let testEnv: TestEnvWithSessions
+let graphQLRequest: GraphQLRequest
+
+beforeAll(async () => {
+  testEnv = await configTestEnv()
+  graphQLRequest = testEnv.testArgs.graphQLRequest
+})
+
+afterAll(async () => {
+  await testEnv.disconnect()
+})
+
+describe('Search Resolver', () => {
+  // Define the search query we'll use in every request
+  const searchQuery = `
+  query Search($query: String!) {
+    search(query: $query) {
+      __typename
+      title
+      preview
+      permalink
+      ... on ArticleResult {
+        date
+        labels {
+          name
+        }
+      }
+    }
+  }
+  `
+
+  it('returns results for mixed types', async () => {
+    /*
+    Query String: 'myvector', case insensitive
+    Search Fields Tested: 
+        Article.title, Article.slug, Article.preview
+        Bookmark.label, bookmark.url
+    Expected Results: 
+        myVector (BookmarkResult)
+        searchTermArticleData (ArticleResult)
+    
+    */
+
+    const searchResults = await graphQLRequest({
+      query: searchQuery,
+      variables: {
+        query: 'myvector',
+      },
+    }).expect(200)
+
+    const results = searchResults.body.data.search
+
+    expect(results).toHaveLength(2)
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          __typename: 'BookmarkResult',
+          title: myVector.label,
+          permalink: myVector.url,
+          preview: myVector.description,
+        }),
+        expect.objectContaining({
+          __typename: 'ArticleResult',
+          title: searchTermArticleData.title,
+          permalink: searchTermArticleData.slug,
+          preview: searchTermArticleData.preview,
+          date: expect.any(String),
+          labels: [searchTermArticleData.labels.create],
+        }),
+      ])
+    )
+  })
+
+  it('returns results by searching bookmark URL', async () => {
+    /*
+    Query String: 'afpcsecure.us.af.mil'
+    Search Fields Tested: Bookmark.url
+    Expected Results: 
+        surf (BookmarkResult)
+        orders (BookmarkResult)
+    */
+
+    const searchResults = await graphQLRequest({
+      query: searchQuery,
+      variables: {
+        query: 'afpcsecure.us.af.mil',
+      },
+    }).expect(200)
+
+    const results = searchResults.body.data.search
+
+    expect(results).toHaveLength(2)
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          __typename: 'BookmarkResult',
+          title: surf.label,
+          permalink: surf.url,
+          preview: surf.description,
+        }),
+        expect.objectContaining({
+          __typename: 'BookmarkResult',
+          title: orders.label,
+          permalink: orders.url,
+          preview: orders.description,
+        }),
+      ])
+    )
+  })
+
+  it('returns results by searching keywords', async () => {
+    /*
+    Query String: 'FOO', case insensitive
+    Search Fields Tested: Article.keywords, Bookmark.keywords
+    Expected Results: 
+        publishedArticleData (ArticleResult)
+        orders (BookmarkResult)
+    */
+
+    const searchResults = await graphQLRequest({
+      query: searchQuery,
+      variables: {
+        query: 'FOO',
+      },
+    }).expect(200)
+
+    const results = searchResults.body.data.search
+
+    expect(results).toHaveLength(2)
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          __typename: 'ArticleResult',
+          title: publishedArticleData.title,
+          permalink: publishedArticleData.slug,
+          preview: publishedArticleData.preview,
+          labels: [publishedArticleData.labels.create],
+          date: expect.any(String),
+        }),
+        expect.objectContaining({
+          __typename: 'BookmarkResult',
+          title: orders.label,
+          permalink: orders.url,
+          preview: orders.description,
+        }),
+      ])
+    )
+  })
+
+  it('does not return articles with draft status', async () => {
+    /*
+    Query String: 'draft', case insensitive
+    Search Fields Tested: Article.status
+    Expected Results: []
+    */
+
+    const searchResults = await graphQLRequest({
+      query: searchQuery,
+      variables: {
+        query: 'draft',
+      },
+    }).expect(200)
+
+    const results = searchResults.body.data.search
+
+    expect(results).toHaveLength(0)
+  })
+
+  it('returns results by searching bookmark descriptions', async () => {
+    /*
+    Query String: 'career', case insensitive
+    Search Fields Tested: Bookmark.description
+    Expected Results: 
+        myVector (BookmarkResult)
+        surf (BookmarkResult)
+    */
+
+    const searchResults = await graphQLRequest({
+      query: searchQuery,
+      variables: {
+        query: 'career',
+      },
+    }).expect(200)
+
+    const results = searchResults.body.data.search
+
+    expect(results).toHaveLength(2)
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          __typename: 'BookmarkResult',
+          title: surf.label,
+          permalink: surf.url,
+          preview: surf.description,
+        }),
+        expect.objectContaining({
+          __typename: 'BookmarkResult',
+          title: myVector.label,
+          permalink: myVector.url,
+          preview: myVector.description,
+        }),
+      ])
+    )
+  })
+})

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -115,7 +115,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
         }))
 
         // Search Article table
-        // Fields: title, preview, keywords
+        // Fields: title, preview, keywords, labels, tags
         // #TODO: Add field searchBody
         const articleResults = (
           await prisma.article.findMany({

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -145,6 +145,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
                 },
               ],
               status: 'Published',
+              category: 'InternalNews',
             },
 
             include: {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -76,43 +76,43 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
 
         // Search Bookmark table
         // Fields: label, url, description, keywords
-        // const bookmarkResults = (
-        //   await prisma.bookmark.findMany({
-        //     where: {
-        //       OR: [
-        //         {
-        //           description: {
-        //             search: terms,
-        //             mode: 'insensitive',
-        //           },
-        //         },
-        //         {
-        //           label: {
-        //             search: terms,
-        //             mode: 'insensitive',
-        //           },
-        //         },
-        //         {
-        //           url: {
-        //             contains: terms,
-        //             mode: 'insensitive',
-        //           },
-        //         },
-        //         {
-        //           keywords: {
-        //             search: terms,
-        //             mode: 'insensitive',
-        //           },
-        //         },
-        //       ],
-        //     },
-        //   })
-        // ).map((bookmark) => ({
-        //   type: 'Bookmark',
-        //   title: bookmark.label,
-        //   url: bookmark.url,
-        //   description: bookmark.description,
-        // }))
+        const bookmarkResults = (
+          await prisma.bookmark.findMany({
+            where: {
+              OR: [
+                {
+                  description: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  label: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  url: {
+                    contains: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  keywords: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+              ],
+            },
+          })
+        ).map((bookmark) => ({
+          type: 'Bookmark',
+          title: bookmark.label,
+          permalink: bookmark.url,
+          preview: bookmark.description,
+        }))
 
         // Search Article table
         // Fields: title, preview, keywords, labels, tags
@@ -157,7 +157,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
           date: article.publishedDate?.toISOString(),
         }))
 
-        return [articleResults]
+        return [...bookmarkResults, ...articleResults]
       },
     },
   },

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -76,43 +76,43 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
 
         // Search Bookmark table
         // Fields: label, url, description, keywords
-        const bookmarkResults = (
-          await prisma.bookmark.findMany({
-            where: {
-              OR: [
-                {
-                  description: {
-                    search: terms,
-                    mode: 'insensitive',
-                  },
-                },
-                {
-                  label: {
-                    search: terms,
-                    mode: 'insensitive',
-                  },
-                },
-                {
-                  url: {
-                    contains: terms,
-                    mode: 'insensitive',
-                  },
-                },
-                {
-                  keywords: {
-                    search: terms,
-                    mode: 'insensitive',
-                  },
-                },
-              ],
-            },
-          })
-        ).map((bookmark) => ({
-          type: 'Bookmark',
-          title: bookmark.label,
-          permalink: bookmark.url,
-          preview: bookmark.description,
-        }))
+        // const bookmarkResults = (
+        //   await prisma.bookmark.findMany({
+        //     where: {
+        //       OR: [
+        //         {
+        //           description: {
+        //             search: terms,
+        //             mode: 'insensitive',
+        //           },
+        //         },
+        //         {
+        //           label: {
+        //             search: terms,
+        //             mode: 'insensitive',
+        //           },
+        //         },
+        //         {
+        //           url: {
+        //             contains: terms,
+        //             mode: 'insensitive',
+        //           },
+        //         },
+        //         {
+        //           keywords: {
+        //             search: terms,
+        //             mode: 'insensitive',
+        //           },
+        //         },
+        //       ],
+        //     },
+        //   })
+        // ).map((bookmark) => ({
+        //   type: 'Bookmark',
+        //   title: bookmark.label,
+        //   url: bookmark.url,
+        //   description: bookmark.description,
+        // }))
 
         // Search Article table
         // Fields: title, preview, keywords, labels, tags

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -15,6 +15,7 @@ const typeDefs = gql`
   }
 
   interface SearchResultItem {
+    id: String!
     title: String!
     preview: String!
     type: SearchResultType!
@@ -22,6 +23,7 @@ const typeDefs = gql`
   }
 
   type BookmarkResult implements SearchResultItem {
+    id: String!
     title: String!
     preview: String!
     type: SearchResultType!
@@ -29,6 +31,7 @@ const typeDefs = gql`
   }
 
   type ArticleResult implements SearchResultItem {
+    id: String!
     title: String!
     preview: String!
     type: SearchResultType!
@@ -108,6 +111,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
             },
           })
         ).map((bookmark) => ({
+          id: bookmark.id,
           type: 'Bookmark',
           title: bookmark.label,
           permalink: bookmark.url,
@@ -149,6 +153,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
             },
           })
         ).map((article) => ({
+          id: article.id,
           type: 'Article',
           title: article.title,
           permalink: article.slug,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -157,7 +157,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
           date: article.publishedDate?.toISOString(),
         }))
 
-        return [...bookmarkResults, ...articleResults]
+        return [articleResults]
       },
     },
   },

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,108 @@
+import { graphQLSchemaExtension } from '@keystone-6/core'
+import type { Context } from '.keystone/types'
+
+export const SearchSchema = graphQLSchemaExtension<Context>({
+  typeDefs: `
+        type Query {
+            """ Search """
+            search(query: String!): [SearchResultItem]
+        }
+
+        enum SearchResultItemType {
+            Article
+            Bookmark
+        }
+
+        type SearchResultItem {
+            type: SearchResultItemType
+            title: String!
+            url: String!
+            description: String!
+        }
+    `,
+  resolvers: {
+    Query: {
+      search: async (root, { query }, { session, db, prisma }) => {
+        // Split our terms and search for each one using OR
+        const terms = query.split(' ').join('|')
+
+        // Search Bookmark table
+        // Fields: label, url, description, keywords
+        const bookmarkResults = (
+          await prisma.bookmark.findMany({
+            where: {
+              OR: [
+                {
+                  description: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  label: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  url: {
+                    contains: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  keywords: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+              ],
+            },
+          })
+        ).map((bookmark) => ({
+          type: 'Bookmark',
+          title: bookmark.label,
+          url: bookmark.url,
+          description: bookmark.description,
+        }))
+
+        // Search Article table
+        // Fields: title, preview, keywords
+        // #TODO: Add field searchBody
+        const articleResults = (
+          await prisma.article.findMany({
+            where: {
+              OR: [
+                {
+                  title: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  preview: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+                {
+                  keywords: {
+                    search: terms,
+                    mode: 'insensitive',
+                  },
+                },
+              ],
+            },
+          })
+        ).map((article) => ({
+          type: 'Article',
+          title: article.title,
+          url: article.slug,
+          description: article.preview,
+        }))
+
+        return [...bookmarkResults, ...articleResults]
+      },
+    },
+  },
+})

--- a/src/testData.ts
+++ b/src/testData.ts
@@ -1,0 +1,58 @@
+// Bookmarks
+export const myVector = {
+  label: 'MyVector',
+  url: 'https://myvector.us.af.mil/myvector/Home/Dashboard',
+  description: 'Manage your desired career path.',
+}
+
+export const surf = {
+  label: 'SURF',
+  url: 'https://afpcsecure.us.af.mil/',
+  description: 'A one page summary of your career found on AMS',
+}
+
+export const orders = {
+  label: 'Orders',
+  url: 'https://afpcsecure.us.af.mil/',
+  description: 'View PCS orders through vMPF.',
+  keywords: 'foo',
+}
+
+export const testBookmarks = [myVector, surf, orders]
+
+// Articles
+export const publishedArticleData = {
+  title: 'Test Article',
+  slug: 'test-article',
+  category: 'InternalNews',
+  status: 'Published',
+  preview: 'A test article that is published.',
+  keywords: 'foo',
+  publishedDate: new Date().toISOString(),
+  labels: { create: { name: 'All Guardians' } },
+}
+
+export const draftArticleData = {
+  title: 'Draft Article',
+  slug: 'draft-article',
+  category: 'InternalNews',
+  status: 'Draft',
+  preview: 'A test article that is a draft.',
+  keywords: 'bar',
+}
+
+export const searchTermArticleData = {
+  title: 'New MyVector Launch',
+  slug: 'new-my-vector',
+  category: 'InternalNews',
+  status: 'Published',
+  publishedDate: new Date().toISOString(),
+  preview: 'This will match on the search term MyVector.',
+  labels: { create: { name: 'Internal USSF News' } },
+}
+
+export const testArticles = [
+  publishedArticleData,
+  draftArticleData,
+  searchTermArticleData,
+]

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -17,6 +17,7 @@ export const testConfig = config({
     provider: 'postgresql',
     url: TEST_DATABASE_CONNECTION,
     useMigrations: true,
+    prismaPreviewFeatures: ['fullTextSearch'],
   },
   lists,
 })

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -10,8 +10,6 @@ import type { User } from '.prisma/client'
 import { lists } from './schema'
 import { extendGraphqlSchema } from './lib/schema'
 
-import { testArticles, testBookmarks } from './testData'
-
 const TEST_DATABASE = 'unit-test'
 const TEST_DATABASE_CONNECTION = `postgres://keystone:keystonecms@0.0.0.0:5432/${TEST_DATABASE}`
 
@@ -86,9 +84,6 @@ export const configTestEnv = async (): Promise<TestEnvWithSessions> => {
     data: testUsers,
     query: userQuery,
   })
-
-  await sudoContext.query.Article.createMany({ data: testArticles })
-  await sudoContext.query.Bookmark.createMany({ data: testBookmarks })
 
   const adminUser = users.find((u) => u.userId === adminUserData.userId) as User
   const cmsUser = users.find((u) => u.userId === userUserData.userId) as User

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -8,6 +8,9 @@ import { KeystoneContext } from '@keystone-6/core/types'
 
 import type { User } from '.prisma/client'
 import { lists } from './schema'
+import { extendGraphqlSchema } from './lib/schema'
+
+import { testArticles, testBookmarks } from './testData'
 
 const TEST_DATABASE = 'unit-test'
 const TEST_DATABASE_CONNECTION = `postgres://keystone:keystonecms@0.0.0.0:5432/${TEST_DATABASE}`
@@ -20,6 +23,7 @@ export const testConfig = config({
     prismaPreviewFeatures: ['fullTextSearch'],
   },
   lists,
+  extendGraphqlSchema,
 })
 
 const adminUserData = {
@@ -82,6 +86,9 @@ export const configTestEnv = async (): Promise<TestEnvWithSessions> => {
     data: testUsers,
     query: userQuery,
   })
+
+  await sudoContext.query.Article.createMany({ data: testArticles })
+  await sudoContext.query.Bookmark.createMany({ data: testBookmarks })
 
   const adminUser = users.find((u) => u.userId === adminUserData.userId) as User
   const cmsUser = users.find((u) => u.userId === userUserData.userId) as User


### PR DESCRIPTION
# SC-376

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

* Adds a search query resolver to Keystone
* Returns search results for bookmarks and articles (except the body text)
* Adds a search result interface, BookmarkResult type, and ArticleResult type

### To Do
- [x] Write tests

## Reviewer notes

* ~Do we need any other data for the search results?~ [Synced with Suz about FE requirements]
* ~We store a slug for an article, is this enough for url since we know if it's an article?~ [For now, slug is fine]
* Other style suggestions always welcome!

All database queries are using full-text search except url for Bookmarks. This is because if we want to match on part of the url, we need to use `contains`. The catch: Matching any little bit of the substring could be confusing, e.g. searching 'car' and getting a match on `tricareonline.com/`. There is probably further optimization to be done.


## Setup

## Code review steps

* Run the services, portal, and cms
* Log in to cms, and go to `localhost:3001/api/graphql`
* Use the following query to test
```
query Search($query: String!) {
  search(query: $query) {
    __typename
    title
    preview
    permalink
    ... on ArticleResult {
      date
      labels {
        name
      }
    }
  }
}
```
* Pass in a search term of your choice in query variables
```
{ "query": "myfss"}
```
* Confirm you get back the results you expected.
You can add articles when logged in as cmsadmin to broaden your search results and test the ability to get multiple types of matches in one query.

<img width="1618" alt="Screen Shot 2022-06-13 at 3 02 50 PM" src="https://user-images.githubusercontent.com/6007259/173452806-6d86a63c-dc0e-44fe-bbe6-b70a56aaa19d.png">

**If you experience any weirdness with prisma errors, `rm -rf` the .keystone directory and try again.**


### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Playwright
  - [ ] Including [axe-playwright](https://github.com/abhinaba-ghosh/axe-playwright) checks when UI changes
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
