### PR TITLE
feat: Add Label type field

### DIFF
--- a/migrations/20220615160126_add_label_type/migration.sql
+++ b/migrations/20220615160126_add_label_type/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `type` to the `Label` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "LabelTypeType" AS ENUM ('Source', 'Audience', 'Base');
+
+-- AlterTable
+ALTER TABLE "Label" ADD COLUMN     "type" "LabelTypeType" NOT NULL;

--- a/schema.graphql
+++ b/schema.graphql
@@ -627,10 +627,17 @@ input LocationCreateInput {
 type Label {
   id: ID!
   name: String
+  type: LabelTypeType
   updatedBy: User
   createdBy: User
   updatedAt: DateTime
   createdAt: DateTime
+}
+
+enum LabelTypeType {
+  Source
+  Audience
+  Base
 }
 
 input LabelWhereUniqueInput {
@@ -644,21 +651,31 @@ input LabelWhereInput {
   NOT: [LabelWhereInput!]
   id: IDFilter
   name: StringFilter
+  type: LabelTypeTypeNullableFilter
   updatedBy: UserWhereInput
   createdBy: UserWhereInput
   updatedAt: DateTimeNullableFilter
   createdAt: DateTimeNullableFilter
 }
 
+input LabelTypeTypeNullableFilter {
+  equals: LabelTypeType
+  in: [LabelTypeType!]
+  notIn: [LabelTypeType!]
+  not: LabelTypeTypeNullableFilter
+}
+
 input LabelOrderByInput {
   id: OrderDirection
   name: OrderDirection
+  type: OrderDirection
   updatedAt: OrderDirection
   createdAt: OrderDirection
 }
 
 input LabelUpdateInput {
   name: String
+  type: LabelTypeType
 }
 
 input LabelUpdateArgs {
@@ -668,6 +685,7 @@ input LabelUpdateArgs {
 
 input LabelCreateInput {
   name: String
+  type: LabelTypeType
 }
 
 type Tag {

--- a/schema.prisma
+++ b/schema.prisma
@@ -133,15 +133,16 @@ model Location {
 }
 
 model Label {
-  id                  String    @id @default(cuid())
-  name                String    @unique @default("")
-  updatedBy           User?     @relation("Label_updatedBy", fields: [updatedById], references: [id])
-  updatedById         String?   @map("updatedBy")
-  createdBy           User?     @relation("Label_createdBy", fields: [createdById], references: [id])
-  createdById         String?   @map("createdBy")
-  updatedAt           DateTime? @updatedAt
-  createdAt           DateTime? @default(now())
-  from_Article_labels Article[] @relation("Article_labels")
+  id                  String        @id @default(cuid())
+  name                String        @unique @default("")
+  type                LabelTypeType
+  updatedBy           User?         @relation("Label_updatedBy", fields: [updatedById], references: [id])
+  updatedById         String?       @map("updatedBy")
+  createdBy           User?         @relation("Label_createdBy", fields: [createdById], references: [id])
+  createdById         String?       @map("createdBy")
+  updatedAt           DateTime?     @updatedAt
+  createdAt           DateTime?     @default(now())
+  from_Article_labels Article[]     @relation("Article_labels")
 
   @@index([updatedById])
   @@index([createdById])
@@ -214,6 +215,12 @@ enum UserRoleType {
   User
   Author
   Manager
+}
+
+enum LabelTypeType {
+  Source
+  Audience
+  Base
 }
 
 enum ArticleCategoryType {

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -43,6 +43,7 @@ describe('Search Resolver', () => {
         date
         labels {
           name
+          type
         }
       }
     }
@@ -85,7 +86,7 @@ describe('Search Resolver', () => {
           permalink: searchTermArticleData.slug,
           preview: searchTermArticleData.preview,
           date: expect.any(String),
-          labels: [searchTermArticleData.labels.create],
+          labels: [],
         }),
       ])
     )

--- a/src/lists/Label.test.ts
+++ b/src/lists/Label.test.ts
@@ -10,6 +10,7 @@ describe('Label schema', () => {
 
   const testLabel = {
     name: 'My Label',
+    type: 'Source',
   }
 
   beforeAll(async () => {
@@ -26,7 +27,7 @@ describe('Label schema', () => {
     it('can create a new label', async () => {
       const data = await adminContext.query.Label.createOne({
         data: testLabel,
-        query: 'id name createdAt updatedAt',
+        query: 'id name createdAt updatedAt type',
       })
 
       expect(data).toMatchObject({
@@ -79,7 +80,7 @@ describe('Label schema', () => {
       // Create new Label for non admin tests
       const newLabel = await adminContext.query.Label.createOne({
         data: testLabel,
-        query: 'id name createdAt updatedAt',
+        query: 'id name createdAt updatedAt type',
       })
 
       expect(newLabel).toMatchObject({
@@ -94,7 +95,7 @@ describe('Label schema', () => {
   describe('as a non admin user', () => {
     it('can query all labels', async () => {
       const data = await userContext.query.Label.findMany({
-        query: 'id createdAt updatedAt name',
+        query: 'id createdAt updatedAt name type',
       })
 
       expect(data).toHaveLength(1)

--- a/src/lists/Label.ts
+++ b/src/lists/Label.ts
@@ -1,10 +1,16 @@
 import { list } from '@keystone-6/core'
-import { text } from '@keystone-6/core/fields'
+import { select, text } from '@keystone-6/core/fields'
 
 import type { Lists } from '.keystone/types'
 
-import { isAdmin, editReadAdminUI, canCreateArticle } from '../util/access'
+import { isAdmin, editReadAdminUI } from '../util/access'
 import { withTracking } from '../util/tracking'
+
+const LABEL_TYPES = {
+  SOURCE: 'Source',
+  AUDIENCE: 'Audience',
+  BASE: 'Base',
+}
 
 const Label: Lists.Label = list(
   withTracking({
@@ -31,6 +37,18 @@ const Label: Lists.Label = list(
           isRequired: true,
         },
         isIndexed: 'unique',
+      }),
+      type: select({
+        type: 'enum',
+        options: (
+          Object.keys(LABEL_TYPES) as Array<keyof typeof LABEL_TYPES>
+        ).map((r) => ({
+          label: LABEL_TYPES[r],
+          value: LABEL_TYPES[r],
+        })),
+        validation: {
+          isRequired: true,
+        },
       }),
     },
   })

--- a/src/testData.ts
+++ b/src/testData.ts
@@ -29,7 +29,7 @@ export const publishedArticleData = {
   preview: 'A test article that is published.',
   keywords: 'foo',
   publishedDate: new Date().toISOString(),
-  labels: { create: { name: 'All Guardians' } },
+  labels: { create: { name: 'All Guardians', type: 'Audience' } },
 }
 
 export const draftArticleData = {
@@ -48,7 +48,6 @@ export const searchTermArticleData = {
   status: 'Published',
   publishedDate: new Date().toISOString(),
   preview: 'This will match on the search term MyVector.',
-  labels: { create: { name: 'Internal USSF News' } },
 }
 
 export const testArticles = [


### PR DESCRIPTION
# SC-593

## Proposed changes

Since we have 3 different UI treatments for Labels based on what kind of information the label is conveying, I added a `type` field to the Label schema. It is required since there is no default Label design, and can be one of the following options: `Source, Audience, Base`. More Label types can be added in the future as needed, but should also correspond to design updates.

---

## Reviewer notes

- Verify if you log into the CMS as an admin user, you can create a Label with a type selected.

## Setup

- `yarn dev` to start the CMS locally, which should also run migrations
- The migrations will fail if you already have Labels created. If this is the case you can reset your local DB with: `yarn keystone dev --reset-db` (this will delete all data from your local Keystone database). In our deployed environments, there don't appear to be any existing Labels, so this should not happen (if it does that means there are Labels in the database and we can delete them).
 
---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed