### PR TITLE
chore: adding a script to snapshot RDS prior to a deploy

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -62,7 +62,7 @@ jobs:
           RDS_INSTANCE: ${{ secrets.RDS_INSTANCE }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          ./scripts/snapshot-docdb.sh
+          ./scripts/snapshot-rds.sh
 
       - name: Download task definition | Update Task Definition | Update ECS Service | Deploy new image
         env:

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -57,6 +57,13 @@ jobs:
           build-args: |
             BUILD=${{ github.sha }}
 
+      - name: Snapshot RDS
+        env:
+          RDS_INSTANCE: ${{ secrets.RDS_INSTANCE }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          ./scripts/snapshot-docdb.sh
+
       - name: Download task definition | Update Task Definition | Update ECS Service | Deploy new image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/scripts/snapshot-rds.sh
+++ b/scripts/snapshot-rds.sh
@@ -6,7 +6,7 @@ SSID=rdsss-$(date +"%s")
 
 # Create Snapshot
 aws rds create-db-snapshot \
-  --db-instance-identifier terraform-20220214212230326300000001 \
+  --db-instance-identifier ${RDS_INSTANCE} \
   --db-snapshot-identifier $SSID --tags Key=sha,Value=${IMAGE_TAG}
 
 # RDS Snapshot

--- a/scripts/snapshot-rds.sh
+++ b/scripts/snapshot-rds.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+set -e
+
+# Snapshot ID `rdsss-epoch`
+SSID=rdsss-$(date +"%s")
+
+# Create Snapshot
+aws rds create-db-snapshot \
+  --db-instance-identifier terraform-20220214212230326300000001 \
+  --db-snapshot-identifier $SSID --tags Key=sha,Value=${IMAGE_TAG}
+
+# RDS Snapshot
+RDSSS=$(aws rds describe-db-snapshots --db-snapshot-identifier $SSID |jq -r '.DBSnapshots[]' | jq -r '.Status')
+
+# Don't do anything else until it's available
+# aws docdb does not have a `wait`
+until [ "$DBSS" = "available" ]
+    do
+      DBSS=$(aws rds describe-db-snapshots --db-snapshot-identifier $SSID |jq -r '.DBSnapshots[]' | jq -r '.Status')
+      echo $RDSSS
+      sleep 30
+    done
+    echo "$SSID available!"
+    continue

--- a/scripts/snapshot-rds.sh
+++ b/scripts/snapshot-rds.sh
@@ -21,4 +21,3 @@ until [ "$DBSS" = "available" ]
       sleep 30
     done
     echo "$SSID available!"
-    continue


### PR DESCRIPTION
# SC-652

Like snapshotting DocumentDB for Portal-Client, this snapshots RDS (postgres) during a deploy and waits for the snapshot to exist before deploying.