### PR TITLE
chore: disabling the dismissal of stale reviews

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -148,7 +148,7 @@ branches:
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 1
-        dismiss_stale_reviews: true
+        dismiss_stale_reviews: false
         require_code_owner_reviews: true
         dismissal_restrictions:
           users: []


### PR DESCRIPTION
I unchecked the box, but was unaware that this was managed here. So updating the bool to reflect that we don't want to dismiss a review.