### PR TITLE
ci: adding security type to conventional commit

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -30,6 +30,7 @@ jobs:
             revert
             style
             test
+            security
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -131,6 +131,10 @@
       {
         "type": "docs",
         "section": "Documentation"
+      },
+      {
+        "type": "security",
+        "section": "Security Improvements"
       }
     ]
   }


### PR DESCRIPTION
Like https://github.com/USSF-ORBIT/ussf-portal-client/pull/757 this adds `security` as a type for commit messages.