### PR TITLE
ci: build docker cache and push to aws ecr

### DIFF
--- a/.github/workflows/cache-to-ecr.yml
+++ b/.github/workflows/cache-to-ecr.yml
@@ -1,0 +1,88 @@
+name: Docker build and cache to AWS ECR
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
+    branches: [main]
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
+    branches: [main]
+
+jobs:
+  build-and-push-dev-aws:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+
+      - name: Get tag
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # tag=v1
+        with:
+          aws-access-key-id: ${{ secrets.GHA_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GHA_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.GHA_ECR_ROLE_ASSUMPTION }}
+          role-skip-session-tagging: true
+          role-duration-seconds: '3600'
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f # tag=v1
+
+      - name: Login to ECR
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # tag=v2
+        with:
+          registry: ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # tag=v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}
+          tags: |
+            type=sha,prefix=,format=long
+          flavor: |
+            latest=false
+            
+      - uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # tag=v2
+        id: buildx
+        with:
+          install: true
+
+      - name: Read CMS version from package.json
+        run: echo ::set-output name=cmsVersion::$(node -p "require('./package.json').version")
+        id: details
+
+      - name: Build and push
+        uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # tag=v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/keystone:builder
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=inline
+          target: builder
+          build-args: |
+            BUILD=${{ github.sha }}
+            CMS_VERSION=${{ steps.details.outputs.cmsVersion }}
+      - name: Build and push
+        uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # tag=v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/keystone:e2e
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=inline
+          target: e2e
+          build-args: |
+            BUILD=${{ github.sha }}
+            CMS_VERSION=${{ steps.details.outputs.cmsVersion }}

--- a/.github/workflows/cache-to-ecr.yml
+++ b/.github/workflows/cache-to-ecr.yml
@@ -1,4 +1,4 @@
-name: Docker build and cache to AWS ECR
+name: Docker Build Cache Push AWS ECR
 
 on:
   workflow_dispatch:
@@ -73,7 +73,7 @@ jobs:
           build-args: |
             BUILD=${{ github.sha }}
             CMS_VERSION=${{ steps.details.outputs.cmsVersion }}
-            
+
       - name: Build and push
         uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # tag=v3
         with:

--- a/.github/workflows/cache-to-ecr.yml
+++ b/.github/workflows/cache-to-ecr.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
-
       - name: Get tag
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
 
@@ -52,7 +51,7 @@ jobs:
             type=sha,prefix=,format=long
           flavor: |
             latest=false
-            
+
       - uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # tag=v2
         id: buildx
         with:
@@ -74,6 +73,7 @@ jobs:
           build-args: |
             BUILD=${{ github.sha }}
             CMS_VERSION=${{ steps.details.outputs.cmsVersion }}
+            
       - name: Build and push
         uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94 # tag=v3
         with:


### PR DESCRIPTION
# SC-916

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- build docker image with cache in-line
- push image with cache to AWS ECR, allowing other workflows to utilize the cache to speed up builds


---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

Once merged to Main, the workflow can be run on dispatch and tested there. There is no anticipated effect on any existing workflows.

## Setup



---

## Code review steps


### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in subsequent PRs or stories

### As code reviewer(s), I have

- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged