### PR TITLE
ci: only triger cache-to-ecr on push to main

### DIFF
--- a/.github/workflows/cache-to-ecr.yml
+++ b/.github/workflows/cache-to-ecr.yml
@@ -7,11 +7,6 @@ on:
       - 'docs/**'
       - '**.md**'
     branches: [main]
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md**'
-    branches: [main]
 
 jobs:
   build-and-push-dev-aws:


### PR DESCRIPTION
# SC-916

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- cache-to-ecr.yml runs too often because it is triggered on Pull Requests. Change to only trigger on Push to Main

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---

## Code review steps
