### PR TITLE
chore(release): 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.4.4](https://github.com/USSF-ORBIT/ussf-portal-cms/compare/1.4.3...1.4.4) (2022-09-16)
+
+
+### Security Improvements
+
+* bump moment-timezone from 0.5.34 to 0.5.37 ([#134](https://github.com/USSF-ORBIT/ussf-portal-cms/issues/134)) ([6b37f6c](https://github.com/USSF-ORBIT/ussf-portal-cms/commit/6b37f6ce5bef5abdcc3ec4149d768e9418bcca7f))
+
 ### [1.4.3](https://github.com/USSF-ORBIT/ussf-portal-cms/compare/1.4.2...1.4.3) (2022-08-24)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussf-portal-cms",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
# SC-1129

### [1.4.4](https://github.com/USSF-ORBIT/ussf-portal-cms/compare/1.4.3...1.4.4) (2022-09-16)


### Security Improvements

* bump moment-timezone from 0.5.34 to 0.5.37 ([#134](https://github.com/USSF-ORBIT/ussf-portal-cms/issues/134)) ([6b37f6c](https://github.com/USSF-ORBIT/ussf-portal-cms/commit/6b37f6ce5bef5abdcc3ec4149d768e9418bcca7f))
