### PR TITLE
dev: extend connection timeout to keystone db

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -31,7 +31,7 @@ export SESSION_DOMAIN=localhost
 ###################################
 # Database/Services Configuration #
 ###################################
-export DATABASE_URL=postgres://keystone:keystonecms@0.0.0.0:5432/keystone
+export DATABASE_URL=postgres://keystone:keystonecms@0.0.0.0:5432/keystone?connect_timeout=10
 export REDIS_URL=redis://localhost:6379
 
 export RDS_TLS_CERT=rds-combined-ca-bundle.pem

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Environment variables for Postgres are set in the `docker-compose.services.yml` 
 
 If running on standard port 5432, this makes the connection url one of the following:
 
-- `postgres://keystone:keystonecms@host.docker.internal:6666/keystone` (connecting from one docker container to another)
-- `postgres://keystone:keystonecms@0.0.0.0:5432/keystone` (connecting from host machine)
+- `postgres://keystone:keystonecms@host.docker.internal:6666/keystone?connect_timeout=10` (connecting from one docker container to another)
+- `postgres://keystone:keystonecms@0.0.0.0:5432/keystone?connect_timeout=10` (connecting from host machine)
 
 Caveat: If you're also running Postgres on your local machine, you may run into some port conflicts with the Postgres Docker container. In the docker-compose file, you can map `5432` to an unused port to resolve.
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -13,15 +13,17 @@ services:
       - '3001:3001'
     environment:
       PORT: 3001
-      DATABASE_URL: postgres://keystone:keystonecms@keystone-db:5432/test
+      DATABASE_URL: postgres://keystone:keystonecms@keystone-db:5432/test?connect_timeout=10
       REDIS_URL: redis://portal_redis:6379
       SESSION_SECRET: thisvaluecanbeanythingitisonlyforlocaldevelopment
       SESSION_DOMAIN: localhost
       PORTAL_URL: http://localhost:3000
     stdin_open: true
     depends_on:
-      - keystone-db
-      - redis
+      keystone-db:
+        condition: service_healthy
+      redis:
+        condition: service_started
 
   # Portal client
   app:
@@ -94,3 +96,9 @@ services:
       - POSTGRES_PASSWORD=keystonecms
       - POSTGRES_USER=keystone
       - POSTGRES_DB=test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=keystone --dbname=test"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -11,7 +11,7 @@ import { lists } from './schema'
 import { extendGraphqlSchema } from './lib/schema'
 
 const TEST_DATABASE = 'unit-test'
-const TEST_DATABASE_CONNECTION = `postgres://keystone:keystonecms@0.0.0.0:5432/${TEST_DATABASE}`
+const TEST_DATABASE_CONNECTION = `postgres://keystone:keystonecms@0.0.0.0:5432/${TEST_DATABASE}?connect_timeout=10`
 
 export const testConfig = config({
   db: {


### PR DESCRIPTION
# SC-1012

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- extend the connection timeout from CMS App to Keystone DB from the default 5 seconds to 10 seconds

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

This change only modifies how environment variables operates locally. In AWS, the connection string will have to be modified in AWS Systems Manager Parameter Store.

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

