### PR TITLE
security: address remaining undici dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "standard-version": "9.5.0"
   },
   "resolutions": {
-    "undici": "5.8.2"
-    "busboy": "0.3.1",
+    "undici": "5.8.2",
+    "busboy": "0.3.1"
   },
   "engines": {
     "node": "14.20.1"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "standard-version": "9.5.0"
   },
   "resolutions": {
-    "undici": "5.5.1"
+    "undici": "5.8.2"
   },
   "engines": {
     "node": "14.20.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10683,10 +10683,10 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-undici@5.0.0, undici@5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.5.1.tgz#baaf25844a99eaa0b22e1ef8d205bffe587c8f43"
-  integrity sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==
+undici@5.0.0, undici@5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.8.2.tgz#071fc8a6a5d24db0ad510ad442f607d9b09d5eec"
+  integrity sha512-3KLq3pXMS0Y4IELV045fTxqz04Nk9Ms7yfBBHum3yxsTR4XNn+ZCaUbf/mWitgYDAhsplQ0B1G4S5D345lMO3A==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The remaining dependabot alerts need 5.8.0 or 5.8.2 so pushing 5.8.2. 