### PR TITLE
build: migrate cms runner and e2e stages to distroless node 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14.20.1-slim AS builder
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends openssl libc6 yarn
+    && apt-get install -y --no-install-recommends openssl libc6 yarn zlib1g
 
 WORKDIR /app
 
@@ -25,6 +25,11 @@ FROM gcr.io/distroless/nodejs:14 AS e2e
 WORKDIR /app
 
 COPY --from=builder /app /app
+
+COPY --from=builder /lib/x86_64-linux-gnu/libz*  /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libexpat*  /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libhistory*  /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libreadline*  /lib/x86_64-linux-gnu/
 
 ENV NODE_ENV production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN yarn install --production --ignore-scripts --prefer-offline
 ##--------- Stage: e2e ---------##
 # E2E image for running tests (same as prod but without certs)
 FROM gcr.io/distroless/nodejs:14 AS e2e
+# The below image is an arm64 debug image that has helpful binaries for debugging, such as a shell, for local debugging
+# FROM gcr.io/distroless/nodejs:16-debug-arm64 AS e2e
 
 WORKDIR /app
 
@@ -30,6 +32,12 @@ COPY --from=builder /lib/x86_64-linux-gnu/libz*  /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libexpat*  /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libhistory*  /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libreadline*  /lib/x86_64-linux-gnu/
+
+# The below copies are for hosts running on ARM64, such as M1 Macbooks. Uncomment the lines below and comment out the equivalent lines above.
+# COPY --from=builder /lib/aarch64-linux-gnu/libz*  /lib/aarch64-linux-gnu/
+# COPY --from=builder /lib/aarch64-linux-gnu/libexpat*  /lib/aarch64-linux-gnu/
+# COPY --from=builder /lib/aarch64-linux-gnu/libhistory*  /lib/aarch64-linux-gnu/
+# COPY --from=builder /lib/aarch64-linux-gnu/libreadline*  /lib/aarch64-linux-gnu/
 
 ENV NODE_ENV production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,7 @@ RUN yarn install --production --ignore-scripts --prefer-offline
 
 ##--------- Stage: e2e ---------##
 # E2E image for running tests (same as prod but without certs)
-FROM node:14.20.1-slim AS e2e
-
-RUN apt-get update \
-    && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends openssl libc6 yarn python dumb-init
+FROM gcr.io/distroless/nodejs:14 AS e2e
 
 WORKDIR /app
 
@@ -35,7 +31,10 @@ ENV NODE_ENV production
 EXPOSE 3001
 ENV NEXT_TELEMETRY_DISABLED 1
 
-CMD ["bash", "-c", "/app/node_modules/.bin/prisma migrate deploy && node -r /app/startup/index.js /app/node_modules/.bin/keystone start"]
+COPY --from=builder /bin/sh  /bin/sh
+
+ENTRYPOINT [ "/bin/sh", "-c" ]
+CMD ["/nodejs/bin/node /app/node_modules/.bin/prisma migrate deploy && /nodejs/bin/node -r /app/startup/index.js /app/node_modules/.bin/keystone start"]
 
 
 ##--------- Stage: build-env ---------##


### PR DESCRIPTION
# SC-596

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- Migrates `e2e` and `runner` stages of Dockerfile from `node:14.20.1-slim` to `gcr.io/distroless/nodejs:14`
- Adds a `build-env` stage that builds required libraries and certificates for the runner stage (artifacts of stage are discarded after the stage completes)

The ADR is here: https://github.com/USSF-ORBIT/ussf-portal/pull/159
---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

If you have an M1 Macbook, while this PR is checkout out in USSF-PORTAL-CLIENT comment out this line in Dockerfile:
```
FROM gcr.io/distroless/nodejs:14 AS e2e
```
and uncomment this: 
```
# FROM gcr.io/distroless/nodejs:16-debug-arm64 AS e2e
```

As well, comment out the COPY commands that start with `COPY --from=builder /lib/x86_64-linux-gnu/` and uncomment the ones that start with `# COPY --from=builder /lib/aarch64-linux-gnu/`. This will ensure that the correct libraries are copied for ARM64 CPUs.

Skip the above step if you do not have an M1 Mac.

Then you can go to USSF-PORTAL/e2e and run `yarn services:up`. This will build the app in a distroless container up to the e2e stage.

---

## Code review steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in subsequent PRs or stories

### As code reviewer(s), I have

- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged

