### PR TITLE
chore(deps): update amannn/action-semantic-pull-request action to v5 …

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint pr title
-        uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7 # tag=v4.6.0
+        uses: amannn/action-semantic-pull-request@01d5fd8a8ebb9aafe902c40c53f0f4744f7381eb # tag=v5.0.2
         with:
           wip: true
           types: |


### PR DESCRIPTION
Reapplies (#192)

This time the SHA of the updated action has been added to the list of approved actions.

Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>