### PR TITLE
chore: replacing deprecated set-output

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -39,7 +39,7 @@ jobs:
               insecure = true
 
       - name: Read CMS version from package.json
-        run: echo ::set-output name=cmsVersion::$(node -p "require('./package.json').version")
+        run: echo "{cmsVersion}={$(node -p "require('./package.json').version")}" >> $GITHUB_OUTPUT
         id: details
 
       - name: Build
@@ -65,5 +65,5 @@ jobs:
 
           docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
           docker push $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image::$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG"
+          echo "{image}={$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG}" >> $GITHUB_OUTPUT
           docker logout $C1_REGISTRY

--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -39,7 +39,7 @@ jobs:
               insecure = true
 
       - name: Read CMS version from package.json
-        run: echo "{cmsVersion}={$(node -p "require('./package.json').version")}" >> $GITHUB_OUTPUT
+        run: echo "cmsVersion=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
         id: details
 
       - name: Build
@@ -65,5 +65,5 @@ jobs:
 
           docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
           docker push $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG
-          echo "{image}={$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "image=$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
           docker logout $C1_REGISTRY

--- a/.github/workflows/cache-to-ecr.yml
+++ b/.github/workflows/cache-to-ecr.yml
@@ -53,7 +53,7 @@ jobs:
           install: true
 
       - name: Read CMS version from package.json
-        run: echo ::set-output name=cmsVersion::$(node -p "require('./package.json').version")
+        run: echo "{cmsVersion}={$(node -p "require('./package.json').version")}" >> $GITHUB_OUTPUT
         id: details
 
       - name: Build and push

--- a/.github/workflows/cache-to-ecr.yml
+++ b/.github/workflows/cache-to-ecr.yml
@@ -53,7 +53,7 @@ jobs:
           install: true
 
       - name: Read CMS version from package.json
-        run: echo "{cmsVersion}={$(node -p "require('./package.json').version")}" >> $GITHUB_OUTPUT
+        run: echo "cmsVersion=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
         id: details
 
       - name: Build and push

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -52,7 +52,7 @@ jobs:
           install: true
 
       - name: Read CMS version from package.json
-        run: echo ::set-output name=cmsVersion::$(node -p "require('./package.json').version")
+        run: echo "{cmsVersion}={$(node -p "require('./package.json').version")}" >> $GITHUB_OUTPUT
         id: details
 
       - name: Build and push

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -52,7 +52,7 @@ jobs:
           install: true
 
       - name: Read CMS version from package.json
-        run: echo "{cmsVersion}={$(node -p "require('./package.json').version")}" >> $GITHUB_OUTPUT
+        run: echo "cmsVersion=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
         id: details
 
       - name: Build and push

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
 
       - name: Read Node.js version from package.json
-        run: echo "{nodeVersion}={$(node -p "require('./package.json').engines.node")}" >> $GITHUB_OUTPUT
+        run: echo "nodeVersion=$(node -p "require('./package.json').engines.node")" >> $GITHUB_OUTPUT
         id: engines
 
       - name: Set up node

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
 
       - name: Read Node.js version from package.json
-        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        run: echo "{nodeVersion}={$(node -p "require('./package.json').engines.node")}" >> $GITHUB_OUTPUT
         id: engines
 
       - name: Set up node
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@1c73980b09e7aea7201f325a7aa3ad00beddcdda # tag=v3
         id: yarn-cache

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@1c73980b09e7aea7201f325a7aa3ad00beddcdda # tag=v3
         id: yarn-cache
@@ -41,7 +41,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-yarn-${{ steps.yarn-cache-dir-path.outputs.dir }}
 
       # The yarn cache is not node_modules
       - name: Install dependencies


### PR DESCRIPTION
# SC-1371

Replacing soon to be deprecated `set-output` with the recommendated pattern per the [docs](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
