### PR TITLE
build: switch CODEOWNERS to use group code-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Default owners for everything
 
-* @abbyoung @esacteksab @gidjin @minhlai
+* @USSF-ORBIT/code-owners
 
 # Github settings
 
-.github/settings.yml @abbyoung @esacteksab @gidjin @minhlai
+.github/settings.yml @USSF-ORBIT/code-owners
 
 # CODEOWNERS prevent renovate automerge since it will automatically ask for review
 


### PR DESCRIPTION
# SC-1348

Also resolves SC-1349

## Proposed changes

Instead of creating a PR to add or remove code owners this adds a github group to manage the same thing.

## Reviewer notes

I've created PRs for this in the portal (USSF-ORBIT/ussf-portal#185), client (USSF-ORBIT/ussf-portal-client#902), and cms (this pr) repos.