### PR TITLE
dev: update github setting to ensure pr title used for main merge messages

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,6 +8,7 @@ repository:
   has_wiki: true
   default_branch: main
   allow_squash_merge: true
+  squash_merge_commit_title: PR_TITLE # ensure PR title is used as squash merge message
   # This will allow merge commits on branches, but only squash merges allowed on main (below)
   allow_merge_commit: true
   allow_rebase_merge: true


### PR DESCRIPTION
## Proposed changes

Enable setting to use PR title as squash merge commit message by default.
