### PR TITLE
ci: only push to c1 artifactory on release publication

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -1,11 +1,8 @@
 name: Docker Build Main Push C1 Artifactory
 
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md**'
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Proposed changes

<!-- description and/or list of proposed changes -->
- We decided to push to C1 Artifactory only when a release is published rather than every time something is pushed to Main. A manual workflow dispatch can still be used to push any branch to Artifactory.
---
<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->
