### PR TITLE
fix: order renovate packagerules in ascending order of importance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,22 +15,22 @@
   },
   "packageRules": [
     {
-      "description": "Group updates for Keystone into a single PR",
-      "groupName": "keystone",
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchPackagePrefixes": ["@keystone"],
-      "labels": ["keystone"]
-    },
-    {
       "rebaseWhen": "behind-base-branch",
       "matchUpdateTypes": ["patch", "minor", "pin", "digest"]
     },
     {
-      "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
       "managers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group minor and patch updates for devDependencies into a single PR",
+      "groupName": "devDependencies",
+      "managers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["devDependencies"]
     },
     {
       "managers": ["dockerfile"],
@@ -42,6 +42,13 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "labels": ["github-actions"]
+    },
+    {
+      "description": "Group updates for Keystone into a single PR",
+      "groupName": "keystone",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackagePrefixes": ["@keystone"],
+      "labels": ["keystone"]
     }
   ],
   "ignorePresets": [":prHourlyLimit2"]

--- a/renovate.json
+++ b/renovate.json
@@ -6,22 +6,26 @@
     "npm:unpublishSafe",
     "packages:eslint",
     "packages:jsUnitTest",
-    "group:nodeJs"
+    "group:nodeJs",
+    "group:linters"
   ],
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "description": "Group updates for Keystone into a single PR",
       "groupName": "keystone",
-      "matchPackageNames": ["node"],
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackagePrefixes": ["@keystone"]
+      "matchPackagePrefixes": ["@keystone"],
+      "labels": ["keystone"]
     },
     {
       "rebaseWhen": "behind-base-branch",
       "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
       "automerge": true,
-      "lockFileMaintenance": { "enabled": true },
-      "labels": ["dependencies"]
+      "lockFileMaintenance": { "enabled": true }
     },
     {
       "automerge": true,
@@ -39,7 +43,7 @@
       "groupName": "github-actions",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
-      "labels": ["dependencies"]
+      "labels": ["github-actions"]
     }
   ],
   "ignorePresets": [":prHourlyLimit2"]

--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
     {
       "groupName": "github-actions",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "labels": ["dependencies"]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -23,9 +23,7 @@
     },
     {
       "rebaseWhen": "behind-base-branch",
-      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
-      "automerge": true,
-      "lockFileMaintenance": { "enabled": true }
+      "matchUpdateTypes": ["patch", "minor", "pin", "digest"]
     },
     {
       "automerge": true,

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,17 @@
     ":dependencyDashboard",
     "npm:unpublishSafe",
     "packages:eslint",
-    "packages:jsUnitTest"
+    "packages:jsUnitTest",
+    "group:nodeJs"
   ],
   "packageRules": [
+    {
+      "description": "Group updates for Keystone into a single PR",
+      "groupName": "keystone",
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackagePrefixes": ["@keystone"]
+    },
     {
       "rebaseWhen": "behind-base-branch",
       "matchUpdateTypes": ["patch", "minor", "pin", "digest"],


### PR DESCRIPTION
## Proposed changes

<!-- description and/or list of proposed changes -->

---
- Order renovate packagerules in ascending order of importance. This is because Renovate actually evaluates every rule without stopping and allows a rule to override earlier rules. Previously they were ordered in descending order of importance.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

