### PR TITLE
build: download ca bundle without strict cert check and verify sha256 sum

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
 
       - run: |
-          sudo sh scripts/add-dod-cas.sh
+          sudo bash scripts/add-dod-cas.sh
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -11,7 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
 
-      - run: |
+      - name: Add DoD Certificate Bundle
+        env:
+          CERT_BUNDLE_SHA256: ${{ secrets.DOD_CA_CERT_BUNDLE_SHA256 }}
+        run: |
+          echo "$CERT_BUNDLE_SHA256" > scripts/dod_ca_cert_bundle.sha256
           sudo bash scripts/add-dod-cas.sh
 
       - name: Docker meta

--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -4,11 +4,20 @@
 
     # Location of bundle from DISA site
     bundle=https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_DoD.zip
-
+    # Copy the Checksum file
+    cp ./scripts/certificates_pkcs7_v5_11_dod.sha256 /usr/local/share/ca-certificates/
     # Extract the bundle
     cd /usr/local/share/ca-certificates
     wget $bundle
     unzip unclass-certificates_pkcs7_DoD.zip
+
+    # check that Checksums verify
+    output=$(cd certificates_pkcs7_v5_11_dod; openssl smime -verify -in ../certificates_pkcs7_v5_11_dod.sha256 -inform DER -CAfile dod_pke_chain.pem | dos2unix | sha256sum -c)
+    echo $output
+    if [[ "$output" == *"FAILED"* ]]; then
+        echo "Checksum failed" >&2
+        exit 1
+    fi
 
     # Convert the PKCS#7 bundle into individual PEM files
     openssl pkcs7 -print_certs -in certificates_pkcs7_v5_11_dod/*_pem.p7b |

--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -4,15 +4,17 @@
 
     # Location of bundle from DISA site
     bundle=https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_DoD.zip
+
     # Copy the Checksum file
-    cp ./scripts/certificates_pkcs7_v5_11_dod.sha256 /usr/local/share/ca-certificates/
+    cp ./scripts/dod_ca_cert_bundle.sha256 /usr/local/share/ca-certificates/
+
     # Extract the bundle
     cd /usr/local/share/ca-certificates
-    wget $bundle
+    wget --no-check-certificate $bundle
     unzip unclass-certificates_pkcs7_DoD.zip
 
     # check that Checksums verify
-    output=$(cd certificates_pkcs7_v5_11_dod; openssl smime -verify -in ../certificates_pkcs7_v5_11_dod.sha256 -inform DER -CAfile dod_pke_chain.pem | dos2unix | sha256sum -c)
+    output=$(cd certificates_pkcs7_v5_11_dod; sha256sum -c --strict ../dod_ca_cert_bundle.sha256)
     echo $output
     if [[ "$output" == *"FAILED"* ]]; then
         echo "Checksum failed" >&2


### PR DESCRIPTION
<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- added a checksum file for Certs in DoD PKI CA Cert bundle from GH Secrets
- modfiy `add-dod-cas.sh` to download Cert bundle without strict TLS verification
- modify `add-dod.cas.sh` to verify the sha256 checksum of the certs that are downloaded against the checksum file to deter MITM attacks
---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Code review steps

The workflow `.github/workflows/build-push-c1-art.yml` was tested with a manual dispatch and the results can be seen here: https://github.com/USSF-ORBIT/ussf-portal-cms/actions/runs/4724254188/jobs/8381246053

The output of the `Add DoD Certifaction Bundle` should include this:
```
 Verification successful
certificates_pkcs7_v5_11_dod_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_3_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_4_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_5_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_6_der.p7b: OK certificates_pkcs7_v5_11_dod_pem.p7b: OK dod_pke_chain.pem: OK README.txt: OK
```
Which indicates that the checksum has passed. The rest of the build has been canceled as to not waste space on Dev Artifactory.
