### PR TITLE
dev: cleanup lint warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     "security"
   ],
   "rules": {
-    "no-console": "warn",
+    "no-console": "off",
     "security/detect-object-injection": "error",
     "import/no-useless-path-segments": "warn",
     "import/no-cycle": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
   ],
   "rules": {
     "no-console": "warn",
+    "security/detect-object-injection": "error",
     "import/no-useless-path-segments": "warn",
     "import/no-cycle": "error",
     "import/no-extraneous-dependencies": "error",

--- a/src/lists/Label.ts
+++ b/src/lists/Label.ts
@@ -38,11 +38,9 @@ const Label = list(
       }),
       type: select({
         type: 'enum',
-        options: (
-          Object.keys(LABEL_TYPES) as Array<keyof typeof LABEL_TYPES>
-        ).map((r) => ({
-          label: LABEL_TYPES[r],
-          value: LABEL_TYPES[r],
+        options: Object.entries(LABEL_TYPES).map(([, v]) => ({
+          label: v,
+          value: v,
         })),
         validation: {
           isRequired: true,

--- a/src/lists/User.ts
+++ b/src/lists/User.ts
@@ -106,9 +106,10 @@ const User = list(
 
       role: select({
         type: 'enum',
-        options: (
-          Object.keys(USER_ROLES) as Array<keyof typeof USER_ROLES>
-        ).map((r) => ({ label: USER_ROLES[r], value: USER_ROLES[r] })),
+        options: Object.entries(USER_ROLES).map(([, v]) => ({
+          label: v,
+          value: v,
+        })),
         defaultValue: USER_ROLES.USER,
         validation: {
           isRequired: true,

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -45,14 +45,6 @@ type ItemViewFn = ({
   item?: BaseItem
 }) => 'edit' | 'read' | 'hidden'
 
-type ListViewFn = ({
-  session,
-  context,
-}: {
-  session?: ValidSession
-  context?: KeystoneContext
-}) => 'read' | 'hidden'
-
 /** User Roles */
 export const USER_ROLES = {
   USER: 'User',
@@ -60,7 +52,7 @@ export const USER_ROLES = {
   MANAGER: 'Manager',
 } as const
 
-export type UserRole = typeof USER_ROLES[keyof typeof USER_ROLES]
+export type UserRole = (typeof USER_ROLES)[keyof typeof USER_ROLES]
 
 /** Access helpers */
 export const isAdmin: OperationAccessFn = ({ session }) => !!session?.isAdmin

--- a/src/util/tracking.ts
+++ b/src/util/tracking.ts
@@ -59,9 +59,13 @@ export const logging =
             ? Object.entries(item as BaseItem)
                 .filter(
                   ([key, value]) =>
+                    // key is from the item we are tracking
+                    // eslint-disable-next-line security/detect-object-injection
                     key === 'id' || value !== originalItem?.[key]
                 )
                 .reduce((acc, [k, v]) => {
+                  // k is from the item we are tracking
+                  // eslint-disable-next-line security/detect-object-injection
                   acc[k] = v
                   return acc
                 }, {} as Record<string, unknown>)

--- a/startup/logging.js
+++ b/startup/logging.js
@@ -76,6 +76,7 @@ function setUpLogging() {
    */
   const loggingProperties = ['log', 'debug', 'info', 'warn', 'error']
   for (const property of loggingProperties) {
+    // eslint-disable-next-line security/detect-object-injection
     console[property] = getLoggingFunction(property)
   }
 

--- a/startup/logging.js
+++ b/startup/logging.js
@@ -19,6 +19,9 @@ function setUpLogging() {
   // testCircular.d = testCircular
 
   function getLoggingFunction(/** @type {string} */ levelName) {
+    // levelName is passed in by this setup code when calling this function
+    // not user input
+    // eslint-disable-next-line security/detect-object-injection
     const baseLogFn = (logger[levelName] || logger.info).bind(logger)
     return function patchedLog(/** @type {any[]} */ ...parts) {
       /** @type {object | undefined} */
@@ -62,6 +65,8 @@ function setUpLogging() {
       continue
     }
 
+    // property is not a user provided value but code from nextjs
+    // eslint-disable-next-line security/detect-object-injection
     nextBuiltInLogger[property] = getLoggingFunction(property)
   }
 


### PR DESCRIPTION
## Proposed changes

This has been on my mind for a while. I made `security/detect-object-injection` as error level lint issues. This will break the build if you add any. This PR fixes a couple issues and marks the rest as accepted exceptions to that.  This PR also disabled `no-console` as a warning since we use `console` messages for server side logging. See https://eslint.org/docs/latest/rules/no-console

I am doing this because it is easy to ignore warnings and I wanted to help reduce that concern and allow us to document when we add exceptions to that. 

This is a proposal and not necessarily how we need to do things so feel free to push back on making the two lint checks error level vs warning level.

## Reviewer notes

Review the fixes and any comments disabling specific lines for accuracy and clarity.

NOTE: ADR proposed for this change USSF-ORBIT/ussf-portal#265

## Setup

### Lint should be clear of errors, and no warnings related to console or object injection

```sh
yarn lint
```
