### PR TITLE
chore: allow admins to bypass restrictions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -164,7 +164,7 @@ branches:
           # ['lint-and-test', 'action-semantic-pull-request', 'run-e2e-tests']
           [ 'lint-and-test', 'action-semantic-pull-request' ]
       # Required. Allow owners to by pass restrictions for PRs that are just release notes or github settings changes which do not affect tests
-      # Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      # Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators.
       enforce_admins: false
       # Commits pushed to matching branches must have verified signatures. Set to false to disable.
       required_signatures: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -162,9 +162,10 @@ branches:
         contexts:
           # TODO Temporarily removing e2e tests from required builds as they are flakey and need to be stabilized first
           # ['lint-and-test', 'action-semantic-pull-request', 'run-e2e-tests']
-          ['lint-and-test', 'action-semantic-pull-request']
-      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
+          [ 'lint-and-test', 'action-semantic-pull-request' ]
+      # Required. Allow owners to by pass restrictions for PRs that are just release notes or github settings changes which do not affect tests
+      # Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: false
       # Commits pushed to matching branches must have verified signatures. Set to false to disable.
       required_signatures: true
       required_linear_history: true

--- a/src/lists/Article.ts
+++ b/src/lists/Article.ts
@@ -28,7 +28,7 @@ import { componentBlocks } from '../components/embedVideo'
 // Disable the warning, this regex is only run after checking the max length
 // and only failed with a catastrophic backtrace in testing with extremely
 // large data sets well beyond the current max or anything a url would accept
-// For details see https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/adr/0017-disable-unsafe-regex-in-cms-slug-code.md
+// For details see https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/adr/0018-disable-unsafe-regex-in-cms-slug-code.md
 // eslint-disable-next-line security/detect-unsafe-regex
 const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const SLUG_MAX = 1000


### PR DESCRIPTION
## Proposed changes

Some times our changes don't trigger the build, for example changing documentation or github repo settings. This results in PRs being stuck due to the restrictions. There hasn't been a good way to allow these to be bypassed under certain conditions so we decided to allow admins to be able to bypass the restriction. This should be used sparingly.
