### PR TITLE
build: allow design, eng, and owners merge to main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -175,4 +175,9 @@ branches:
       restrictions:
         apps: []
         users: []
-        teams: []
+        teams:
+          [
+            '@USSF-ORBIT/design',
+            '@USSF-ORBIT/eng',
+            '@USSF-ORBIT/code-owners'
+          ]


### PR DESCRIPTION
## Proposed changes

We have our main branch setup to restrict who can merge. Recently this means folks need to have not just `Write` access to the repo but `Maintainer` access unless granted otherwise. We were not granting any groups this permission so our designers were no longer able to merge their own PRs. This PR changes it so that members of @USSF-ORBIT/design , @USSF-ORBIT/eng , and @USSF-ORBIT/code-owners are allowed to merge PRs to main.

## Reviewer notes

In an effort to grant the minimum I went this route instead of giving everyone `Maintainer` role since that adds ability to change some settings as well.

See thread https://trussworks.slack.com/archives/C025D61NNLQ/p1685991976848249