### PR TITLE
chore: Spike for landing pages

### DIFF
--- a/migrations/20231020221342_test_landing_page/migration.sql
+++ b/migrations/20231020221342_test_landing_page/migration.sql
@@ -1,0 +1,78 @@
+-- CreateTable
+CREATE TABLE "LandingPage" (
+    "id" TEXT NOT NULL,
+    "pageTitle" TEXT NOT NULL DEFAULT '',
+    "pageDescription" TEXT NOT NULL DEFAULT '',
+    "updatedBy" TEXT,
+    "createdBy" TEXT,
+    "updatedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LandingPage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_LandingPage_collections" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_LandingPage_articles" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_LandingPage_documents" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "LandingPage_updatedBy_idx" ON "LandingPage"("updatedBy");
+
+-- CreateIndex
+CREATE INDEX "LandingPage_createdBy_idx" ON "LandingPage"("createdBy");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_LandingPage_collections_AB_unique" ON "_LandingPage_collections"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_LandingPage_collections_B_index" ON "_LandingPage_collections"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_LandingPage_articles_AB_unique" ON "_LandingPage_articles"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_LandingPage_articles_B_index" ON "_LandingPage_articles"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_LandingPage_documents_AB_unique" ON "_LandingPage_documents"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_LandingPage_documents_B_index" ON "_LandingPage_documents"("B");
+
+-- AddForeignKey
+ALTER TABLE "LandingPage" ADD CONSTRAINT "LandingPage_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LandingPage" ADD CONSTRAINT "LandingPage_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LandingPage_collections" ADD CONSTRAINT "_LandingPage_collections_A_fkey" FOREIGN KEY ("A") REFERENCES "Collection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LandingPage_collections" ADD CONSTRAINT "_LandingPage_collections_B_fkey" FOREIGN KEY ("B") REFERENCES "LandingPage"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LandingPage_articles" ADD CONSTRAINT "_LandingPage_articles_A_fkey" FOREIGN KEY ("A") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LandingPage_articles" ADD CONSTRAINT "_LandingPage_articles_B_fkey" FOREIGN KEY ("B") REFERENCES "LandingPage"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LandingPage_documents" ADD CONSTRAINT "_LandingPage_documents_A_fkey" FOREIGN KEY ("A") REFERENCES "DocumentSection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LandingPage_documents" ADD CONSTRAINT "_LandingPage_documents_B_fkey" FOREIGN KEY ("B") REFERENCES "LandingPage"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/migrations/20231020221758_test_migration_category/migration.sql
+++ b/migrations/20231020221758_test_migration_category/migration.sql
@@ -1,0 +1,45 @@
+/*
+  Warnings:
+
+  - The `category` column on the `Article` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Article" DROP COLUMN "category",
+ADD COLUMN     "category" TEXT;
+
+-- DropEnum
+DROP TYPE "ArticleCategoryType";
+
+-- CreateTable
+CREATE TABLE "Category" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "updatedBy" TEXT,
+    "createdBy" TEXT,
+    "updatedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_name_key" ON "Category"("name");
+
+-- CreateIndex
+CREATE INDEX "Category_updatedBy_idx" ON "Category"("updatedBy");
+
+-- CreateIndex
+CREATE INDEX "Category_createdBy_idx" ON "Category"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Article_category_idx" ON "Article"("category");
+
+-- AddForeignKey
+ALTER TABLE "Article" ADD CONSTRAINT "Article_category_fkey" FOREIGN KEY ("category") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/migrations/20231023180046_/migration.sql
+++ b/migrations/20231023180046_/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `pageDescription` column on the `LandingPage` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "LandingPage" DROP COLUMN "pageDescription",
+ADD COLUMN     "pageDescription" JSONB NOT NULL DEFAULT '[{"type":"paragraph","children":[{"text":""}]}]';

--- a/migrations/20231023180634_/migration.sql
+++ b/migrations/20231023180634_/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "LandingPage" ALTER COLUMN "pageDescription" SET DEFAULT '',
+ALTER COLUMN "pageDescription" SET DATA TYPE TEXT;

--- a/migrations/20231023190707_test_category/migration.sql
+++ b/migrations/20231023190707_test_category/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "LandingPage" ADD COLUMN     "category" TEXT;
+
+-- CreateIndex
+CREATE INDEX "LandingPage_category_idx" ON "LandingPage"("category");
+
+-- AddForeignKey
+ALTER TABLE "LandingPage" ADD CONSTRAINT "LandingPage_category_fkey" FOREIGN KEY ("category") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/migrations/20231023235638_sluggo/migration.sql
+++ b/migrations/20231023235638_sluggo/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slug]` on the table `LandingPage` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "LandingPage" ADD COLUMN     "slug" TEXT NOT NULL DEFAULT '';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LandingPage_slug_key" ON "LandingPage"("slug");

--- a/schema.graphql
+++ b/schema.graphql
@@ -606,7 +606,7 @@ input TagCreateInput {
 
 type Article {
   id: ID!
-  category: ArticleCategoryType
+  category: Category
   status: ArticleStatusType
   articlePreviewUrl: JSON
   publishedDate: DateTime
@@ -628,11 +628,6 @@ type Article {
   createdBy: User
   updatedAt: DateTime
   createdAt: DateTime
-}
-
-enum ArticleCategoryType {
-  InternalNews
-  ORBITBlog
 }
 
 enum ArticleStatusType {
@@ -671,7 +666,7 @@ input ArticleWhereInput {
   OR: [ArticleWhereInput!]
   NOT: [ArticleWhereInput!]
   id: IDFilter
-  category: ArticleCategoryTypeNullableFilter
+  category: CategoryWhereInput
   status: ArticleStatusTypeNullableFilter
   publishedDate: DateTimeNullableFilter
   archivedDate: DateTimeNullableFilter
@@ -688,13 +683,6 @@ input ArticleWhereInput {
   createdBy: UserWhereInput
   updatedAt: DateTimeNullableFilter
   createdAt: DateTimeNullableFilter
-}
-
-input ArticleCategoryTypeNullableFilter {
-  equals: ArticleCategoryType
-  in: [ArticleCategoryType!]
-  notIn: [ArticleCategoryType!]
-  not: ArticleCategoryTypeNullableFilter
 }
 
 input ArticleStatusTypeNullableFilter {
@@ -718,7 +706,6 @@ input TagManyRelationFilter {
 
 input ArticleOrderByInput {
   id: OrderDirection
-  category: OrderDirection
   status: OrderDirection
   publishedDate: OrderDirection
   archivedDate: OrderDirection
@@ -732,7 +719,7 @@ input ArticleOrderByInput {
 }
 
 input ArticleUpdateInput {
-  category: ArticleCategoryType
+  category: CategoryRelateToOneForUpdateInput
   status: ArticleStatusType
   publishedDate: DateTime
   archivedDate: DateTime
@@ -747,6 +734,12 @@ input ArticleUpdateInput {
   location: LocationRelateToOneForUpdateInput
   labels: LabelRelateToManyForUpdateInput
   tags: TagRelateToManyForUpdateInput
+}
+
+input CategoryRelateToOneForUpdateInput {
+  create: CategoryCreateInput
+  connect: CategoryWhereUniqueInput
+  disconnect: Boolean
 }
 
 input ImageFieldInput {
@@ -788,7 +781,7 @@ input ArticleUpdateArgs {
 }
 
 input ArticleCreateInput {
-  category: ArticleCategoryType
+  category: CategoryRelateToOneForCreateInput
   status: ArticleStatusType
   publishedDate: DateTime
   archivedDate: DateTime
@@ -803,6 +796,11 @@ input ArticleCreateInput {
   location: LocationRelateToOneForCreateInput
   labels: LabelRelateToManyForCreateInput
   tags: TagRelateToManyForCreateInput
+}
+
+input CategoryRelateToOneForCreateInput {
+  create: CategoryCreateInput
+  connect: CategoryWhereUniqueInput
 }
 
 input BylineRelateToOneForCreateInput {
@@ -1161,6 +1159,145 @@ input ZipcodeCreateInput {
   longitude: Float
 }
 
+type LandingPage {
+  id: ID!
+  pageTitle: String
+  slug: String
+  pageDescription: String
+  category: Category
+  articles(where: ArticleWhereInput! = {}, orderBy: [ArticleOrderByInput!]! = [], take: Int, skip: Int! = 0): [Article!]
+  articlesCount(where: ArticleWhereInput! = {}): Int
+  documents(where: DocumentSectionWhereInput! = {}, orderBy: [DocumentSectionOrderByInput!]! = [], take: Int, skip: Int! = 0): [DocumentSection!]
+  documentsCount(where: DocumentSectionWhereInput! = {}): Int
+  collections(where: CollectionWhereInput! = {}, orderBy: [CollectionOrderByInput!]! = [], take: Int, skip: Int! = 0): [Collection!]
+  collectionsCount(where: CollectionWhereInput! = {}): Int
+  updatedBy: User
+  createdBy: User
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+input LandingPageWhereUniqueInput {
+  id: ID
+  slug: String
+}
+
+input LandingPageWhereInput {
+  AND: [LandingPageWhereInput!]
+  OR: [LandingPageWhereInput!]
+  NOT: [LandingPageWhereInput!]
+  id: IDFilter
+  pageTitle: StringFilter
+  slug: StringFilter
+  pageDescription: StringFilter
+  category: CategoryWhereInput
+  articles: ArticleManyRelationFilter
+  documents: DocumentSectionManyRelationFilter
+  collections: CollectionManyRelationFilter
+  updatedBy: UserWhereInput
+  createdBy: UserWhereInput
+  updatedAt: DateTimeNullableFilter
+  createdAt: DateTimeNullableFilter
+}
+
+input ArticleManyRelationFilter {
+  every: ArticleWhereInput
+  some: ArticleWhereInput
+  none: ArticleWhereInput
+}
+
+input LandingPageOrderByInput {
+  id: OrderDirection
+  pageTitle: OrderDirection
+  slug: OrderDirection
+  pageDescription: OrderDirection
+  updatedAt: OrderDirection
+  createdAt: OrderDirection
+}
+
+input LandingPageUpdateInput {
+  pageTitle: String
+  slug: String
+  pageDescription: String
+  category: CategoryRelateToOneForUpdateInput
+  articles: ArticleRelateToManyForUpdateInput
+  documents: DocumentSectionRelateToManyForUpdateInput
+  collections: CollectionRelateToManyForUpdateInput
+}
+
+input ArticleRelateToManyForUpdateInput {
+  disconnect: [ArticleWhereUniqueInput!]
+  set: [ArticleWhereUniqueInput!]
+  create: [ArticleCreateInput!]
+  connect: [ArticleWhereUniqueInput!]
+}
+
+input LandingPageUpdateArgs {
+  where: LandingPageWhereUniqueInput!
+  data: LandingPageUpdateInput!
+}
+
+input LandingPageCreateInput {
+  pageTitle: String
+  slug: String
+  pageDescription: String
+  category: CategoryRelateToOneForCreateInput
+  articles: ArticleRelateToManyForCreateInput
+  documents: DocumentSectionRelateToManyForCreateInput
+  collections: CollectionRelateToManyForCreateInput
+}
+
+input ArticleRelateToManyForCreateInput {
+  create: [ArticleCreateInput!]
+  connect: [ArticleWhereUniqueInput!]
+}
+
+type Category {
+  id: ID!
+  name: String
+  updatedBy: User
+  createdBy: User
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+input CategoryWhereUniqueInput {
+  id: ID
+  name: String
+}
+
+input CategoryWhereInput {
+  AND: [CategoryWhereInput!]
+  OR: [CategoryWhereInput!]
+  NOT: [CategoryWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  updatedBy: UserWhereInput
+  createdBy: UserWhereInput
+  updatedAt: DateTimeNullableFilter
+  createdAt: DateTimeNullableFilter
+}
+
+input CategoryOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  updatedAt: OrderDirection
+  createdAt: OrderDirection
+}
+
+input CategoryUpdateInput {
+  name: String
+}
+
+input CategoryUpdateArgs {
+  where: CategoryWhereUniqueInput!
+  data: CategoryUpdateInput!
+}
+
+input CategoryCreateInput {
+  name: String
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -1251,6 +1388,18 @@ type Mutation {
   updateZipcodes(data: [ZipcodeUpdateArgs!]!): [Zipcode]
   deleteZipcode(where: ZipcodeWhereUniqueInput!): Zipcode
   deleteZipcodes(where: [ZipcodeWhereUniqueInput!]!): [Zipcode]
+  createLandingPage(data: LandingPageCreateInput!): LandingPage
+  createLandingPages(data: [LandingPageCreateInput!]!): [LandingPage]
+  updateLandingPage(where: LandingPageWhereUniqueInput!, data: LandingPageUpdateInput!): LandingPage
+  updateLandingPages(data: [LandingPageUpdateArgs!]!): [LandingPage]
+  deleteLandingPage(where: LandingPageWhereUniqueInput!): LandingPage
+  deleteLandingPages(where: [LandingPageWhereUniqueInput!]!): [LandingPage]
+  createCategory(data: CategoryCreateInput!): Category
+  createCategories(data: [CategoryCreateInput!]!): [Category]
+  updateCategory(where: CategoryWhereUniqueInput!, data: CategoryUpdateInput!): Category
+  updateCategories(data: [CategoryUpdateArgs!]!): [Category]
+  deleteCategory(where: CategoryWhereUniqueInput!): Category
+  deleteCategories(where: [CategoryWhereUniqueInput!]!): [Category]
   endSession: Boolean!
 }
 
@@ -1297,6 +1446,12 @@ type Query {
   zipcodes(where: ZipcodeWhereInput! = {}, orderBy: [ZipcodeOrderByInput!]! = [], take: Int, skip: Int! = 0): [Zipcode!]
   zipcode(where: ZipcodeWhereUniqueInput!): Zipcode
   zipcodesCount(where: ZipcodeWhereInput! = {}): Int
+  landingPages(where: LandingPageWhereInput! = {}, orderBy: [LandingPageOrderByInput!]! = [], take: Int, skip: Int! = 0): [LandingPage!]
+  landingPage(where: LandingPageWhereUniqueInput!): LandingPage
+  landingPagesCount(where: LandingPageWhereInput! = {}): Int
+  categories(where: CategoryWhereInput! = {}, orderBy: [CategoryOrderByInput!]! = [], take: Int, skip: Int! = 0): [Category!]
+  category(where: CategoryWhereUniqueInput!): Category
+  categoriesCount(where: CategoryWhereInput! = {}): Int
   keystone: KeystoneMeta!
   search(query: String!): [SearchResultItem]
   authenticatedItem: AuthenticatedItem

--- a/schema.prisma
+++ b/schema.prisma
@@ -70,6 +70,10 @@ model User {
   from_DocumentSection_createdBy DocumentSection[] @relation("DocumentSection_createdBy")
   from_DocumentsPage_updatedBy   DocumentsPage[]   @relation("DocumentsPage_updatedBy")
   from_DocumentsPage_createdBy   DocumentsPage[]   @relation("DocumentsPage_createdBy")
+  from_LandingPage_updatedBy     LandingPage[]     @relation("LandingPage_updatedBy")
+  from_LandingPage_createdBy     LandingPage[]     @relation("LandingPage_createdBy")
+  from_Category_updatedBy        Category[]        @relation("Category_updatedBy")
+  from_Category_createdBy        Category[]        @relation("Category_createdBy")
 
   @@index([updatedById])
   @@index([createdById])
@@ -94,16 +98,17 @@ model Bookmark {
 }
 
 model Collection {
-  id              String     @id @default(cuid())
-  title           String     @default("")
-  bookmarks       Bookmark[] @relation("Bookmark_collections")
-  showInSitesApps Boolean    @default(false)
-  updatedBy       User?      @relation("Collection_updatedBy", fields: [updatedById], references: [id])
-  updatedById     String?    @map("updatedBy")
-  createdBy       User?      @relation("Collection_createdBy", fields: [createdById], references: [id])
-  createdById     String?    @map("createdBy")
-  updatedAt       DateTime?  @updatedAt
-  createdAt       DateTime?  @default(now())
+  id                           String        @id @default(cuid())
+  title                        String        @default("")
+  bookmarks                    Bookmark[]    @relation("Bookmark_collections")
+  showInSitesApps              Boolean       @default(false)
+  updatedBy                    User?         @relation("Collection_updatedBy", fields: [updatedById], references: [id])
+  updatedById                  String?       @map("updatedBy")
+  createdBy                    User?         @relation("Collection_createdBy", fields: [createdById], references: [id])
+  createdById                  String?       @map("createdBy")
+  updatedAt                    DateTime?     @updatedAt
+  createdAt                    DateTime?     @default(now())
+  from_LandingPage_collections LandingPage[] @relation("LandingPage_collections")
 
   @@index([updatedById])
   @@index([createdById])
@@ -171,35 +176,38 @@ model Tag {
 }
 
 model Article {
-  id             String              @id @default(cuid())
-  category       ArticleCategoryType
-  status         ArticleStatusType   @default(Draft)
-  publishedDate  DateTime?
-  archivedDate   DateTime?
-  slug           String              @unique @default("")
-  title          String              @default("")
-  preview        String              @default("")
-  hero_filesize  Int?
-  hero_extension String?
-  hero_width     Int?
-  hero_height    Int?
-  hero_id        String?
-  body           Json                @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
-  searchBody     String              @default("")
-  keywords       String              @default("")
-  byline         Byline?             @relation("Article_byline", fields: [bylineId], references: [id])
-  bylineId       String?             @map("byline")
-  location       Location?           @relation("Article_location", fields: [locationId], references: [id])
-  locationId     String?             @map("location")
-  labels         Label[]             @relation("Article_labels")
-  tags           Tag[]               @relation("Article_tags")
-  updatedBy      User?               @relation("Article_updatedBy", fields: [updatedById], references: [id])
-  updatedById    String?             @map("updatedBy")
-  createdBy      User?               @relation("Article_createdBy", fields: [createdById], references: [id])
-  createdById    String?             @map("createdBy")
-  updatedAt      DateTime?           @updatedAt
-  createdAt      DateTime?           @default(now())
+  id                        String            @id @default(cuid())
+  category                  Category?         @relation("Article_category", fields: [categoryId], references: [id])
+  categoryId                String?           @map("category")
+  status                    ArticleStatusType @default(Draft)
+  publishedDate             DateTime?
+  archivedDate              DateTime?
+  slug                      String            @unique @default("")
+  title                     String            @default("")
+  preview                   String            @default("")
+  hero_filesize             Int?
+  hero_extension            String?
+  hero_width                Int?
+  hero_height               Int?
+  hero_id                   String?
+  body                      Json              @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
+  searchBody                String            @default("")
+  keywords                  String            @default("")
+  byline                    Byline?           @relation("Article_byline", fields: [bylineId], references: [id])
+  bylineId                  String?           @map("byline")
+  location                  Location?         @relation("Article_location", fields: [locationId], references: [id])
+  locationId                String?           @map("location")
+  labels                    Label[]           @relation("Article_labels")
+  tags                      Tag[]             @relation("Article_tags")
+  updatedBy                 User?             @relation("Article_updatedBy", fields: [updatedById], references: [id])
+  updatedById               String?           @map("updatedBy")
+  createdBy                 User?             @relation("Article_createdBy", fields: [createdById], references: [id])
+  createdById               String?           @map("createdBy")
+  updatedAt                 DateTime?         @updatedAt
+  createdAt                 DateTime?         @default(now())
+  from_LandingPage_articles LandingPage[]     @relation("LandingPage_articles")
 
+  @@index([categoryId])
   @@index([bylineId])
   @@index([locationId])
   @@index([updatedById])
@@ -253,6 +261,7 @@ model DocumentSection {
   updatedAt                   DateTime?       @updatedAt
   createdAt                   DateTime?       @default(now())
   from_DocumentsPage_sections DocumentsPage[] @relation("DocumentsPage_sections")
+  from_LandingPage_documents  LandingPage[]   @relation("LandingPage_documents")
 
   @@index([updatedById])
   @@index([createdById])
@@ -280,6 +289,44 @@ model Zipcode {
   longitude Float
 }
 
+model LandingPage {
+  id              String            @id @default(cuid())
+  pageTitle       String            @default("")
+  slug            String            @unique @default("")
+  pageDescription String            @default("")
+  category        Category?         @relation("LandingPage_category", fields: [categoryId], references: [id])
+  categoryId      String?           @map("category")
+  articles        Article[]         @relation("LandingPage_articles")
+  documents       DocumentSection[] @relation("LandingPage_documents")
+  collections     Collection[]      @relation("LandingPage_collections")
+  updatedBy       User?             @relation("LandingPage_updatedBy", fields: [updatedById], references: [id])
+  updatedById     String?           @map("updatedBy")
+  createdBy       User?             @relation("LandingPage_createdBy", fields: [createdById], references: [id])
+  createdById     String?           @map("createdBy")
+  updatedAt       DateTime?         @updatedAt
+  createdAt       DateTime?         @default(now())
+
+  @@index([categoryId])
+  @@index([updatedById])
+  @@index([createdById])
+}
+
+model Category {
+  id                        String        @id @default(cuid())
+  name                      String        @unique @default("")
+  updatedBy                 User?         @relation("Category_updatedBy", fields: [updatedById], references: [id])
+  updatedById               String?       @map("updatedBy")
+  createdBy                 User?         @relation("Category_createdBy", fields: [createdById], references: [id])
+  createdById               String?       @map("createdBy")
+  updatedAt                 DateTime?     @updatedAt
+  createdAt                 DateTime?     @default(now())
+  from_Article_category     Article[]     @relation("Article_category")
+  from_LandingPage_category LandingPage[] @relation("LandingPage_category")
+
+  @@index([updatedById])
+  @@index([createdById])
+}
+
 enum UserRoleType {
   User
   Author
@@ -290,11 +337,6 @@ enum LabelTypeType {
   Source
   Audience
   Base
-}
-
-enum ArticleCategoryType {
-  InternalNews
-  ORBITBlog
 }
 
 enum ArticleStatusType {

--- a/src/components/FilteredRelationship.tsx
+++ b/src/components/FilteredRelationship.tsx
@@ -1,0 +1,718 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { Fragment, ReactNode, useState } from 'react'
+
+import { Button } from '@keystone-ui/button'
+import { Inline, jsx, Stack, useTheme } from '@keystone-ui/core'
+import { FieldContainer, FieldLabel, FieldLegend } from '@keystone-ui/fields'
+import { DrawerController } from '@keystone-ui/modals'
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+  ListMeta,
+} from '@keystone-6/core/types'
+import { Link } from '@keystone-6/core/admin-ui/router'
+import { useKeystone, useList } from '@keystone-6/core/admin-ui/context'
+import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo'
+import {
+  CellContainer,
+  CreateItemDrawer,
+} from '@keystone-6/core/admin-ui/components'
+
+import { Field as FilteredRelationshipSelect } from './FilteredRelationshipSelect'
+// TODO: find a way to make this _not_ hardcoded
+
+const CUSTOM_FILTER = '{ "category": { "name": { "equals": "CHCO" } } }'
+function LinkToRelatedItems({
+  itemId,
+  value,
+  list,
+  refFieldKey,
+}: {
+  itemId: string | null
+  value: FieldProps<typeof controller>['value'] & { kind: 'many' | 'one' }
+  list: ListMeta
+  refFieldKey?: string
+}) {
+  function constructQuery({
+    refFieldKey,
+    itemId,
+    value,
+  }: {
+    refFieldKey?: string
+    itemId: string | null
+    value: FieldProps<typeof controller>['value'] & { kind: 'many' | 'one' }
+  }) {
+    if (!!refFieldKey && itemId) {
+      return `!${refFieldKey}_matches="${itemId}"`
+    }
+    return `!id_in="${(value?.value as { id: string; label: string }[])
+      .slice(0, 100)
+      .map(({ id }: { id: string }) => id)
+      .join(',')}"`
+  }
+  const commonProps = {
+    size: 'small',
+    tone: 'active',
+    weight: 'link',
+  } as const
+
+  if (value.kind === 'many') {
+    const query = constructQuery({ refFieldKey, value, itemId })
+    return (
+      <Button {...commonProps} as={Link} href={`/${list.path}?${query}`}>
+        View related {list.plural}
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      {...commonProps}
+      as={Link}
+      href={`/${list.path}/${value.value?.id}`}>
+      View {list.singular} details
+    </Button>
+  )
+}
+
+const RelationshipLinkButton = ({
+  href,
+  children,
+}: {
+  href: string
+  children: ReactNode
+}) => (
+  <Button
+    css={{ padding: 0, height: 'auto' }}
+    weight="link"
+    tone="active"
+    as={Link}
+    href={href}>
+    {children}
+  </Button>
+)
+
+const RelationshipDisplay = ({
+  list,
+  value,
+}: {
+  list: ListMeta
+  value: SingleRelationshipValue | ManyRelationshipValue
+}) => {
+  if (value.kind === 'many') {
+    if (value.value.length) {
+      return (
+        <Inline gap="small">
+          {value.value.map((i) => (
+            <RelationshipLinkButton href={`/${list.path}/${i.id}`}>
+              {i.label}
+            </RelationshipLinkButton>
+          ))}
+        </Inline>
+      )
+    } else {
+      return <div>(No {list.plural})</div>
+    }
+  } else {
+    if (value.value) {
+      return (
+        <RelationshipLinkButton href={`/${list.path}/${value.value.id}`}>
+          {value.value.label}
+        </RelationshipLinkButton>
+      )
+    } else {
+      return <div>(No {list.singular})</div>
+    }
+  }
+}
+
+type FieldPropsCustom = {
+  field: RelationshipController
+  autoFocus: boolean
+  value: FieldProps<typeof controller>['value']
+  onChange: (value: FieldProps<typeof controller>['value']) => void
+  forceValidation: boolean
+  extraFilters?: string
+}
+export const Field = ({
+  field,
+  autoFocus,
+  value,
+  onChange,
+  forceValidation,
+  extraFilters = '',
+}: FieldPropsCustom) => {
+  const keystone = useKeystone()
+  const foreignList = useList(field.refListKey)
+  const localList = useList(field.listKey)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  const authenticatedItem = keystone.authenticatedItem
+
+  return (
+    <FieldContainer as="fieldset">
+      <FieldLabel as="legend">{field.label}</FieldLabel>
+      {onChange ? (
+        <Fragment>
+          <Stack gap="medium">
+            <FilteredRelationshipSelect
+              extraFilters={CUSTOM_FILTER}
+              controlShouldRenderValue
+              autoFocus={autoFocus}
+              isDisabled={onChange === undefined}
+              list={foreignList}
+              portalMenu
+              state={
+                value.kind === 'many'
+                  ? {
+                      kind: 'many',
+                      value: value.value,
+                      onChange(newItems) {
+                        onChange({
+                          ...value,
+                          value: newItems,
+                        })
+                      },
+                    }
+                  : {
+                      kind: 'one',
+                      value: value.value,
+                      onChange(newVal) {
+                        if (value.kind === 'one') {
+                          onChange({
+                            ...value,
+                            value: newVal,
+                          })
+                        }
+                      },
+                    }
+              }
+            />
+            <Stack across gap="small">
+              {!field.hideCreate && (
+                <Button
+                  size="small"
+                  disabled={isDrawerOpen}
+                  onClick={() => {
+                    setIsDrawerOpen(true)
+                  }}>
+                  Create related {foreignList.singular}
+                </Button>
+              )}
+              {authenticatedItem.state === 'authenticated' &&
+                authenticatedItem.listKey === field.refListKey &&
+                (value.kind === 'many'
+                  ? value.value.find((x) => x.id === authenticatedItem.id) ===
+                    undefined
+                  : value.value?.id !== authenticatedItem.id) && (
+                  <Button
+                    size="small"
+                    isDisabled={onChange === undefined}
+                    onClick={() => {
+                      const val = {
+                        label: authenticatedItem.label,
+                        id: authenticatedItem.id,
+                      }
+                      if (value.kind === 'many') {
+                        onChange({
+                          ...value,
+                          value: [...value.value, val],
+                        })
+                      } else {
+                        onChange({
+                          ...value,
+                          value: val,
+                        })
+                      }
+                    }}>
+                    {value.kind === 'many' ? 'Add ' : 'Set as '}
+                    {authenticatedItem.label}
+                  </Button>
+                )}
+              {!!(value.kind === 'many'
+                ? value.value.length
+                : value.kind === 'one' && value.value) && (
+                <LinkToRelatedItems
+                  itemId={value.id}
+                  refFieldKey={field.refFieldKey}
+                  list={foreignList}
+                  value={value}
+                />
+              )}
+            </Stack>
+          </Stack>
+          <DrawerController isOpen={isDrawerOpen}>
+            <CreateItemDrawer
+              listKey={foreignList.key}
+              onClose={() => {
+                setIsDrawerOpen(false)
+              }}
+              onCreate={(val) => {
+                setIsDrawerOpen(false)
+                if (value.kind === 'many') {
+                  onChange({
+                    ...value,
+                    value: [...value.value, val],
+                  })
+                } else if (value.kind === 'one') {
+                  onChange({
+                    ...value,
+                    value: val,
+                  })
+                }
+              }}
+            />
+          </DrawerController>
+        </Fragment>
+      ) : (
+        <RelationshipDisplay value={value} list={foreignList} />
+      )}
+    </FieldContainer>
+  )
+}
+
+export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
+  const list = useList(field.refListKey)
+  const { colors } = useTheme()
+
+  if (field.display === 'count') {
+    const count = item[`${field.path}Count`] ?? 0
+    return (
+      <CellContainer>
+        {count} {count === 1 ? list.singular : list.plural}
+      </CellContainer>
+    )
+  }
+
+  const data = item[field.path]
+  const items = (Array.isArray(data) ? data : [data]).filter((item) => item)
+  const displayItems = items.length < 5 ? items : items.slice(0, 3)
+  const overflow = items.length < 5 ? 0 : items.length - 3
+  const styles = {
+    color: colors.foreground,
+    textDecoration: 'none',
+
+    ':hover': {
+      textDecoration: 'underline',
+    },
+  } as const
+
+  return (
+    <CellContainer>
+      {displayItems.map((item, index) => (
+        <Fragment key={item.id}>
+          {!!index ? ', ' : ''}
+          <Link
+            href={`/${list.path}/[id]`}
+            as={`/${list.path}/${item.id}`}
+            css={styles}>
+            {item.label || item.id}
+          </Link>
+        </Fragment>
+      ))}
+      {overflow ? `, and ${overflow} more` : null}
+    </CellContainer>
+  )
+}
+
+export const CardValue: CardValueComponent<typeof controller> = ({
+  field,
+  item,
+}) => {
+  const list = useList(field.refListKey)
+  const data = item[field.path]
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      {(Array.isArray(data) ? data : [data])
+        .filter((item) => item)
+        .map((item, index) => (
+          <Fragment key={item.id}>
+            {!!index ? ', ' : ''}
+            <Link href={`/${list.path}/[id]`} as={`/${list.path}/${item.id}`}>
+              {item.label || item.id}
+            </Link>
+          </Fragment>
+        ))}
+    </FieldContainer>
+  )
+}
+
+type SingleRelationshipValue = {
+  kind: 'one'
+  id: null | string
+  initialValue: { label: string; id: string } | null
+  value: { label: string; id: string } | null
+}
+type ManyRelationshipValue = {
+  kind: 'many'
+  id: null | string
+  initialValue: { label: string; id: string }[]
+  value: { label: string; id: string }[]
+}
+type CardsRelationshipValue = {
+  kind: 'cards-view'
+  id: null | string
+  itemsBeingEdited: ReadonlySet<string>
+  itemBeingCreated: boolean
+  initialIds: ReadonlySet<string>
+  currentIds: ReadonlySet<string>
+  displayOptions: CardsDisplayModeOptions
+}
+type CountRelationshipValue = {
+  kind: 'count'
+  id: null | string
+  count: number
+}
+type CardsDisplayModeOptions = {
+  cardFields: readonly string[]
+  linkToItem: boolean
+  removeMode: 'disconnect' | 'none'
+  inlineCreate: { fields: readonly string[] } | null
+  inlineEdit: { fields: readonly string[] } | null
+  inlineConnect: boolean
+}
+
+type RelationshipController = FieldController<
+  | ManyRelationshipValue
+  | SingleRelationshipValue
+  | CardsRelationshipValue
+  | CountRelationshipValue,
+  string
+> & {
+  display: 'count' | 'cards-or-select'
+  listKey: string
+  refListKey: string
+  refFieldKey?: string
+  hideCreate: boolean
+  many: boolean
+}
+
+export const controller = (
+  config: FieldControllerConfig<
+    {
+      refFieldKey?: string
+      refListKey: string
+      many: boolean
+      hideCreate: boolean
+    } & (
+      | {
+          displayMode: 'select'
+          refLabelField: string
+        }
+      | {
+          displayMode: 'cards'
+          cardFields: readonly string[]
+          linkToItem: boolean
+          removeMode: 'disconnect' | 'none'
+          inlineCreate: { fields: readonly string[] } | null
+          inlineEdit: { fields: readonly string[] } | null
+          inlineConnect: boolean
+          refLabelField: string
+        }
+      | { displayMode: 'count' }
+    )
+  >
+): RelationshipController => {
+  const cardsDisplayOptions =
+    config.fieldMeta.displayMode === 'cards'
+      ? {
+          cardFields: config.fieldMeta.cardFields,
+          inlineCreate: config.fieldMeta.inlineCreate,
+          inlineEdit: config.fieldMeta.inlineEdit,
+          linkToItem: config.fieldMeta.linkToItem,
+          removeMode: config.fieldMeta.removeMode,
+          inlineConnect: config.fieldMeta.inlineConnect,
+        }
+      : undefined
+
+  return {
+    refFieldKey: config.fieldMeta.refFieldKey,
+    many: config.fieldMeta.many,
+    listKey: config.listKey,
+    path: config.path,
+    label: config.label,
+    display:
+      config.fieldMeta.displayMode === 'count' ? 'count' : 'cards-or-select',
+    refListKey: config.fieldMeta.refListKey,
+    graphqlSelection:
+      config.fieldMeta.displayMode === 'count'
+        ? `${config.path}Count`
+        : `${config.path} {
+              id
+              label: ${config.fieldMeta.refLabelField}
+            }`,
+    hideCreate: config.fieldMeta.hideCreate,
+    // note we're not making the state kind: 'count' when ui.displayMode is set to 'count'.
+    // that ui.displayMode: 'count' is really just a way to have reasonable performance
+    // because our other UIs don't handle relationships with a large number of items well
+    // but that's not a problem here since we're creating a new item so we might as well them a better UI
+    defaultValue:
+      cardsDisplayOptions !== undefined
+        ? {
+            kind: 'cards-view',
+            currentIds: new Set(),
+            id: null,
+            initialIds: new Set(),
+            itemBeingCreated: false,
+            itemsBeingEdited: new Set(),
+            displayOptions: cardsDisplayOptions,
+          }
+        : config.fieldMeta.many
+        ? {
+            id: null,
+            kind: 'many',
+            initialValue: [],
+            value: [],
+          }
+        : { id: null, kind: 'one', value: null, initialValue: null },
+    deserialize: (data) => {
+      if (config.fieldMeta.displayMode === 'count') {
+        return {
+          id: data.id,
+          kind: 'count',
+          count: data[`${config.path}Count`] ?? 0,
+        }
+      }
+      if (cardsDisplayOptions !== undefined) {
+        const initialIds = new Set<string>(
+          (Array.isArray(data[config.path])
+            ? data[config.path]
+            : data[config.path]
+            ? [data[config.path]]
+            : []
+          ).map((x: any) => x.id)
+        )
+        return {
+          kind: 'cards-view',
+          id: data.id,
+          itemsBeingEdited: new Set(),
+          itemBeingCreated: false,
+          initialIds,
+          currentIds: initialIds,
+          displayOptions: cardsDisplayOptions,
+        }
+      }
+      if (config.fieldMeta.many) {
+        let value = (data[config.path] || []).map((x: any) => ({
+          id: x.id,
+          label: x.label || x.id,
+        }))
+        return {
+          kind: 'many',
+          id: data.id,
+          initialValue: value,
+          value,
+        }
+      }
+      let value = data[config.path]
+      if (value) {
+        value = {
+          id: value.id,
+          label: value.label || value.id,
+        }
+      }
+      return {
+        kind: 'one',
+        id: data.id,
+        value,
+        initialValue: value,
+      }
+    },
+    filter: {
+      Filter: ({ onChange, value }) => {
+        const foreignList = useList(config.fieldMeta.refListKey)
+        const { filterValues, loading } = useRelationshipFilterValues({
+          value,
+          list: foreignList,
+        })
+        const state: {
+          kind: 'many'
+          value: { label: string; id: string }[]
+          onChange: (newItems: { label: string; id: string }[]) => void
+        } = {
+          kind: 'many',
+          value: filterValues,
+          onChange(newItems) {
+            onChange(newItems.map((item) => item.id).join(','))
+          },
+        }
+        return (
+          <FilteredRelationshipSelect
+            extraFilters={CUSTOM_FILTER}
+            controlShouldRenderValue
+            list={foreignList}
+            isLoading={loading}
+            isDisabled={onChange === undefined}
+            state={state}
+          />
+        )
+      },
+      graphql: ({ value }) => {
+        const foreignIds = getForeignIds(value)
+        if (config.fieldMeta.many) {
+          return {
+            [config.path]: {
+              some: {
+                id: {
+                  in: foreignIds,
+                },
+              },
+            },
+          }
+        }
+        return {
+          [config.path]: {
+            id: {
+              in: foreignIds,
+            },
+          },
+        }
+      },
+      Label({ value }) {
+        const foreignList = useList(config.fieldMeta.refListKey)
+        const { filterValues } = useRelationshipFilterValues({
+          value,
+          list: foreignList,
+        })
+
+        if (!filterValues.length) {
+          return `has no value`
+        }
+        if (filterValues.length > 1) {
+          const values = filterValues.map((i: any) => i.label).join(', ')
+          return `is in [${values}]`
+        }
+        const optionLabel = filterValues[0].label
+        return `is ${optionLabel}`
+      },
+      types: {
+        matches: {
+          label: 'Matches',
+          initialValue: '',
+        },
+      },
+    },
+    validate(value) {
+      return (
+        value.kind !== 'cards-view' ||
+        (value.itemsBeingEdited.size === 0 && !value.itemBeingCreated)
+      )
+    },
+    serialize: (state) => {
+      if (state.kind === 'many') {
+        const newAllIds = new Set(state.value.map((x) => x.id))
+        const initialIds = new Set(state.initialValue.map((x) => x.id))
+        let disconnect = state.initialValue
+          .filter((x) => !newAllIds.has(x.id))
+          .map((x) => ({ id: x.id }))
+        let connect = state.value
+          .filter((x) => !initialIds.has(x.id))
+          .map((x) => ({ id: x.id }))
+        if (disconnect.length || connect.length) {
+          let output: any = {}
+
+          if (disconnect.length) {
+            output.disconnect = disconnect
+          }
+
+          if (connect.length) {
+            output.connect = connect
+          }
+
+          return {
+            [config.path]: output,
+          }
+        }
+      } else if (state.kind === 'one') {
+        if (state.initialValue && !state.value) {
+          return { [config.path]: { disconnect: true } }
+        } else if (state.value && state.value.id !== state.initialValue?.id) {
+          return {
+            [config.path]: {
+              connect: {
+                id: state.value.id,
+              },
+            },
+          }
+        }
+      } else if (state.kind === 'cards-view') {
+        let disconnect = [...state.initialIds]
+          .filter((id) => !state.currentIds.has(id))
+          .map((id) => ({ id }))
+        let connect = [...state.currentIds]
+          .filter((id) => !state.initialIds.has(id))
+          .map((id) => ({ id }))
+
+        if (config.fieldMeta.many) {
+          if (disconnect.length || connect.length) {
+            return {
+              [config.path]: {
+                connect: connect.length ? connect : undefined,
+                disconnect: disconnect.length ? disconnect : undefined,
+              },
+            }
+          }
+        } else if (connect.length) {
+          return {
+            [config.path]: {
+              connect: connect[0],
+            },
+          }
+        } else if (disconnect.length) {
+          return { [config.path]: { disconnect: true } }
+        }
+      }
+      return {}
+    },
+  }
+}
+
+function useRelationshipFilterValues({
+  value,
+  list,
+}: {
+  value: string
+  list: ListMeta
+}) {
+  const foreignIds = getForeignIds(value)
+  const where = { id: { in: foreignIds } }
+
+  const query = gql`
+    query FOREIGNLIST_QUERY($where: ${list.gqlNames.whereInputName}!) {
+      items: ${list.gqlNames.listQueryName}(where: $where) {
+        id 
+        ${list.labelField}
+      }
+    }
+  `
+
+  const { data, loading } = useQuery(query, {
+    variables: {
+      where,
+    },
+  })
+
+  return {
+    filterValues:
+      data?.items?.map((item: any) => {
+        return {
+          id: item.id,
+          label: item[list.labelField] || item.id,
+        }
+      }) || foreignIds.map((f) => ({ label: f, id: f })),
+    loading: loading,
+  }
+}
+
+function getForeignIds(value: string) {
+  if (typeof value === 'string' && value.length > 0) {
+    return value.split(',')
+  }
+  return []
+}

--- a/src/components/FilteredRelationshipSelect.tsx
+++ b/src/components/FilteredRelationshipSelect.tsx
@@ -1,0 +1,396 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import 'intersection-observer'
+import {
+  RefObject,
+  useEffect,
+  useMemo,
+  useState,
+  createContext,
+  useContext,
+  useRef,
+} from 'react'
+
+import { jsx } from '@keystone-ui/core'
+import { MultiSelect, Select, selectComponents } from '@keystone-ui/fields'
+import { validate as validateUUID } from 'uuid'
+import { IdFieldConfig, ListMeta } from '@keystone-6/core/types'
+import {
+  ApolloClient,
+  gql,
+  InMemoryCache,
+  TypedDocumentNode,
+  useApolloClient,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo'
+
+function useIntersectionObserver(
+  cb: IntersectionObserverCallback,
+  ref: RefObject<any>
+) {
+  const cbRef = useRef(cb)
+  useEffect(() => {
+    cbRef.current = cb
+  })
+  useEffect(() => {
+    let observer = new IntersectionObserver(
+      (...args) => cbRef.current(...args),
+      {}
+    )
+    let node = ref.current
+    if (node !== null) {
+      observer.observe(node)
+      return () => observer.unobserve(node)
+    }
+  }, [ref])
+}
+
+const idValidators = {
+  uuid: validateUUID,
+  cuid(value: string) {
+    return value.startsWith('c')
+  },
+  autoincrement(value: string) {
+    return /^\d+$/.test(value)
+  },
+}
+
+function useDebouncedValue<T>(value: T, limitMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(() => value)
+
+  useEffect(() => {
+    let id = setTimeout(() => {
+      setDebouncedValue(() => value)
+    }, limitMs)
+    return () => {
+      clearTimeout(id)
+    }
+  }, [value, limitMs])
+  return debouncedValue
+}
+
+function useFilter(search: string, list: ListMeta, extraFilters: string) {
+  console.log('💚USER FILTER -- ')
+  console.log('search', search)
+  console.log('list', list)
+  //   console.log('extraFilters', extraFilters)
+  console.log(list.fields.category)
+  return useMemo(() => {
+    let conditions: Record<string, any>[] = [JSON.parse(extraFilters)]
+    if (search.length) {
+      const idFieldKind: IdFieldConfig['kind'] = (
+        list.fields.id.controller as any
+      ).idFieldKind
+      const trimmedSearch = search.trim()
+      const isValidId = idValidators[idFieldKind](trimmedSearch)
+      if (isValidId) {
+        conditions.push({ id: { equals: trimmedSearch } })
+      }
+      for (const field of Object.values(list.fields)) {
+        if (field.search !== null) {
+          conditions.push({
+            [field.path]: {
+              contains: trimmedSearch,
+              mode: field.search === 'insensitive' ? 'insensitive' : undefined,
+            },
+          })
+        }
+      }
+    }
+    return { OR: conditions }
+  }, [search, list])
+}
+
+const initialItemsToLoad = 10
+const subsequentItemsToLoad = 50
+
+const idField = '____id____'
+
+const labelField = '____label____'
+
+const LoadingIndicatorContext = createContext<{
+  count: number
+  ref: (element: HTMLElement | null) => void
+}>({
+  count: 0,
+  ref: () => {},
+})
+
+export const Field = ({
+  autoFocus,
+  controlShouldRenderValue,
+  isDisabled,
+  isLoading,
+  list,
+  placeholder,
+  portalMenu,
+  state,
+  extraSelection = '',
+  extraFilters = '',
+}: {
+  autoFocus?: boolean
+  controlShouldRenderValue: boolean
+  isDisabled: boolean
+  isLoading?: boolean
+  list: ListMeta
+  placeholder?: string
+  portalMenu?: true | undefined
+  state:
+    | {
+        kind: 'many'
+        value: { label: string; id: string; data?: Record<string, any> }[]
+        onChange(
+          value: { label: string; id: string; data: Record<string, any> }[]
+        ): void
+      }
+    | {
+        kind: 'one'
+        value: { label: string; id: string; data?: Record<string, any> } | null
+        onChange(
+          value: { label: string; id: string; data: Record<string, any> } | null
+        ): void
+      }
+  extraSelection?: string
+  extraFilters?: string
+}) => {
+  const [search, setSearch] = useState('')
+  // note it's important that this is in state rather than a ref
+  // because we want a re-render if the element changes
+  // so that we can register the intersection observer
+  // on the right element
+  const [loadingIndicatorElement, setLoadingIndicatorElement] =
+    useState<null | HTMLElement>(null)
+
+  console.log('List ', list)
+  console.log('State ', state)
+
+  const QUERY: TypedDocumentNode<
+    {
+      items: { [idField]: string; [labelField]: string | null }[]
+      count: number
+    },
+    { where: Record<string, any>; take: number; skip: number }
+  > = gql`
+    query RelationshipSelect($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!) {
+      items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip) {
+        ${idField}: id
+        ${labelField}: ${list.labelField}
+        ${extraSelection}
+      }
+      count: ${list.gqlNames.listQueryCountName}(where: $where)
+    }
+  `
+
+  const debouncedSearch = useDebouncedValue(search, 200)
+  const where = useFilter(debouncedSearch, list, extraFilters)
+
+  const link = useApolloClient().link
+  // we're using a local apollo client here because writing a global implementation of the typePolicies
+  // would require making assumptions about how pagination should work which won't always be right
+  const apolloClient = useMemo(
+    () =>
+      new ApolloClient({
+        link,
+        cache: new InMemoryCache({
+          typePolicies: {
+            Query: {
+              fields: {
+                [list.gqlNames.listQueryName]: {
+                  keyArgs: ['where'],
+                  merge: (
+                    existing: readonly unknown[],
+                    incoming: readonly unknown[],
+                    { args }
+                  ) => {
+                    const merged = existing ? existing.slice() : []
+                    const { skip } = args!
+                    for (let i = 0; i < incoming.length; ++i) {
+                      merged[skip + i] = incoming[i]
+                    }
+                    return merged
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    [link, list.gqlNames.listQueryName]
+  )
+
+  const { data, error, loading, fetchMore } = useQuery(QUERY, {
+    fetchPolicy: 'network-only',
+    variables: { where, take: initialItemsToLoad, skip: 0 },
+    client: apolloClient,
+  })
+
+  const count = data?.count || 0
+
+  const options =
+    data?.items?.map(({ [idField]: value, [labelField]: label, ...data }) => ({
+      value,
+      label: label || value,
+      data,
+    })) || []
+
+  const loadingIndicatorContextVal = useMemo(
+    () => ({
+      count,
+      ref: setLoadingIndicatorElement,
+    }),
+    [count]
+  )
+
+  // we want to avoid fetching more again and `loading` from Apollo
+  // doesn't seem to become true when fetching more
+  const [lastFetchMore, setLastFetchMore] = useState<{
+    where: Record<string, any>
+    extraSelection: string
+    list: ListMeta
+    skip: number
+  } | null>(null)
+
+  useIntersectionObserver(
+    ([{ isIntersecting }]) => {
+      const skip = data?.items.length
+      if (
+        !loading &&
+        skip &&
+        isIntersecting &&
+        options.length < count &&
+        (lastFetchMore?.extraSelection !== extraSelection ||
+          lastFetchMore?.where !== where ||
+          lastFetchMore?.list !== list ||
+          lastFetchMore?.skip !== skip)
+      ) {
+        const QUERY: TypedDocumentNode<
+          { items: { [idField]: string; [labelField]: string | null }[] },
+          { where: Record<string, any>; take: number; skip: number }
+        > = gql`
+              query RelationshipSelectMore($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!) {
+                items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip) {
+                  ${labelField}: ${list.labelField}
+                  ${idField}: id
+                  ${extraSelection}
+                }
+              }
+            `
+        setLastFetchMore({ extraSelection, list, skip, where })
+        fetchMore({
+          query: QUERY,
+          variables: {
+            where,
+            take: subsequentItemsToLoad,
+            skip,
+          },
+        })
+          .then(() => {
+            setLastFetchMore(null)
+          })
+          .catch(() => {
+            setLastFetchMore(null)
+          })
+      }
+    },
+    { current: loadingIndicatorElement }
+  )
+
+  // TODO: better error UI
+  // TODO: Handle permission errors
+  // (ie; user has permission to read this relationship field, but
+  // not the related list, or some items on the list)
+  if (error) {
+    return <span>Error</span>
+  }
+
+  if (state.kind === 'one') {
+    return (
+      <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+        <Select
+          // this is necessary because react-select passes a second argument to onInputChange
+          // and useState setters log a warning if a second argument is passed
+          onInputChange={(val) => setSearch(val)}
+          isLoading={loading || isLoading}
+          autoFocus={autoFocus}
+          components={relationshipSelectComponents}
+          portalMenu={portalMenu}
+          value={
+            state.value
+              ? {
+                  value: state.value.id,
+                  label: state.value.label,
+                  // @ts-ignore
+                  data: state.value.data,
+                }
+              : null
+          }
+          options={options}
+          onChange={(value) => {
+            state.onChange(
+              value
+                ? {
+                    id: value.value,
+                    label: value.label,
+                    data: (value as any).data,
+                  }
+                : null
+            )
+          }}
+          placeholder={placeholder}
+          controlShouldRenderValue={controlShouldRenderValue}
+          isClearable={controlShouldRenderValue}
+          isDisabled={isDisabled}
+        />
+      </LoadingIndicatorContext.Provider>
+    )
+  }
+
+  return (
+    <LoadingIndicatorContext.Provider value={loadingIndicatorContextVal}>
+      <MultiSelect // this is necessary because react-select passes a second argument to onInputChange
+        // and useState setters log a warning if a second argument is passed
+        onInputChange={(val) => setSearch(val)}
+        isLoading={loading || isLoading}
+        autoFocus={autoFocus}
+        components={relationshipSelectComponents}
+        portalMenu={portalMenu}
+        value={state.value.map((value) => ({
+          value: value.id,
+          label: value.label,
+          data: value.data,
+        }))}
+        options={options}
+        onChange={(value) => {
+          state.onChange(
+            value.map((x) => ({
+              id: x.value,
+              label: x.label,
+              data: (x as any).data,
+            }))
+          )
+        }}
+        placeholder={placeholder}
+        controlShouldRenderValue={controlShouldRenderValue}
+        isClearable={controlShouldRenderValue}
+        isDisabled={isDisabled}
+      />
+    </LoadingIndicatorContext.Provider>
+  )
+}
+
+const relationshipSelectComponents: Partial<typeof selectComponents> = {
+  MenuList: ({ children, ...props }) => {
+    const { count, ref } = useContext(LoadingIndicatorContext)
+    return (
+      <selectComponents.MenuList {...props}>
+        {children}
+        <div css={{ textAlign: 'center' }} ref={ref}>
+          {props.options.length < count && (
+            <span css={{ padding: 8 }}>Loading...</span>
+          )}
+        </div>
+      </selectComponents.MenuList>
+    )
+  },
+}

--- a/src/components/callToAction.tsx
+++ b/src/components/callToAction.tsx
@@ -37,7 +37,7 @@ export const componentBlocks = {
           article: fields.relationship({
             label: 'Article',
             listKey: 'Article',
-            selection: 'id title slug',
+            selection: 'id title slug category { name }',
           }),
           document: fields.relationship({
             label: 'Document',

--- a/src/lists/Article.ts
+++ b/src/lists/Article.ts
@@ -88,15 +88,10 @@ const Article = list(
     },
 
     fields: {
-      category: select({
-        type: 'enum',
-        options: Object.entries(ARTICLE_CATEGORIES).map(([, v]) => ({
-          label: v,
-          value: v,
-        })),
-        validation: {
-          isRequired: true,
-        },
+      category: relationship({
+        ref: 'Category',
+        many: false,
+        isFilterable: true,
       }),
       status: select({
         type: 'enum',

--- a/src/lists/Category.ts
+++ b/src/lists/Category.ts
@@ -1,0 +1,49 @@
+import { list } from '@keystone-6/core'
+import { text } from '@keystone-6/core/fields'
+
+import {
+  canCreateArticle,
+  articleItemView,
+  canUpdateDeleteArticle,
+} from '../util/access'
+import { withTracking } from '../util/tracking'
+
+const Category = list(
+  withTracking({
+    access: {
+      operation: {
+        create: canCreateArticle,
+        query: () => true,
+        update: () => true,
+        delete: () => true,
+      },
+      filter: {
+        update: canUpdateDeleteArticle,
+        delete: canUpdateDeleteArticle,
+      },
+    },
+
+    ui: {
+      hideCreate: ({ session }) => !canCreateArticle({ session }),
+      hideDelete: ({ session }) => !canCreateArticle({ session }),
+      createView: {
+        defaultFieldMode: ({ session }) =>
+          canCreateArticle({ session }) ? 'edit' : 'hidden',
+      },
+      itemView: {
+        defaultFieldMode: articleItemView,
+      },
+    },
+
+    fields: {
+      name: text({
+        validation: {
+          isRequired: true,
+        },
+        isIndexed: 'unique',
+      }),
+    },
+  })
+)
+
+export default Category

--- a/src/lists/LandingPage.ts
+++ b/src/lists/LandingPage.ts
@@ -1,0 +1,124 @@
+import { list } from '@keystone-6/core'
+import { relationship, text } from '@keystone-6/core/fields'
+import { withTracking } from '../util/tracking'
+import { slugify } from '../util/formatting'
+import { isAdmin } from '../util/access'
+// NOTE:
+// Disable the warning, this regex is only run after checking the max length
+// and only failed with a catastrophic backtrace in testing with extremely
+// large data sets well beyond the current max or anything a url would accept
+// For details see https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/adr/0018-disable-unsafe-regex-in-cms-slug-code.md
+// eslint-disable-next-line security/detect-unsafe-regex
+const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const SLUG_MAX = 1000
+
+const LandingPage = list(
+  withTracking({
+    access: {
+      operation: {
+        create: isAdmin,
+        query: () => true,
+        update: isAdmin,
+        delete: isAdmin,
+      },
+      filter: {
+        update: isAdmin,
+        delete: isAdmin,
+      },
+    },
+    ui: {
+      hideCreate: () => false,
+      hideDelete: () => false,
+      label: 'Landing Page',
+      createView: {
+        defaultFieldMode: 'edit',
+      },
+      itemView: {
+        defaultFieldMode: 'edit',
+      },
+    },
+
+    fields: {
+      pageTitle: text({
+        validation: {
+          isRequired: true,
+        },
+      }),
+      // This field is copied over from Article
+      // #TODO test slug creation works as expected
+      slug: text({
+        isIndexed: 'unique',
+        validation: {
+          length: {
+            max: SLUG_MAX,
+          },
+        },
+        hooks: {
+          resolveInput: async ({ resolvedData, operation }) => {
+            if (operation === 'create' && !resolvedData.slug) {
+              // Default slug to the slugified title
+              // This can still cause validation errors bc titles don't have to be unique
+              return slugify(resolvedData.pageTitle)
+            }
+
+            return resolvedData.slug
+          },
+          validateInput: async ({
+            operation,
+            inputData,
+            fieldKey,
+            resolvedData,
+            addValidationError,
+          }) => {
+            // eslint-disable-next-line no-prototype-builtins
+            if (operation === 'create' || inputData.hasOwnProperty(fieldKey)) {
+              // Validate slug - this has to be done in a hook to allow creating an article with no slug
+              // NOTE: Need to check SLUG_MAX frist to avoid a DOS attack based on the regex see note above.
+              const slug = resolvedData.slug
+              if (!slug) {
+                addValidationError('Slug is a required value')
+              } else if (slug.length > SLUG_MAX) {
+                addValidationError(
+                  `Slug is too long (maximum of ${SLUG_MAX} characters)`
+                )
+              } else if (!SLUG_REGEX.test(slug)) {
+                addValidationError(
+                  'Slug must be a valid slug (only alphanumeric characters and dashes allowed)'
+                )
+              }
+            }
+          },
+        },
+      }),
+      pageDescription: text({
+        ui: {
+          displayMode: 'textarea',
+        },
+      }),
+      category: relationship({
+        ref: 'Category',
+        many: false,
+        // TODO can we use hooks to somehow make sure the category value gets to the articles view
+        // missing some link between the two - still need to fix
+      }),
+      articles: relationship({
+        ref: 'Article',
+        many: true,
+        ui: {
+          displayMode: 'select',
+          views: './src/components/FilteredRelationship.tsx',
+        },
+      }),
+      documents: relationship({
+        ref: 'DocumentSection',
+        many: true,
+      }),
+      collections: relationship({
+        ref: 'Collection',
+        many: true,
+      }),
+    },
+  })
+)
+
+export default LandingPage

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -12,6 +12,8 @@ import Document from './lists/Document'
 import DocumentSection from './lists/DocumentSection'
 import DocumentsPage from './lists/DocumentsPage'
 import Zipcode from './lists/Zipcode'
+import LandingPage from './lists/LandingPage'
+import Category from './lists/Category'
 
 export const lists = {
   Event,
@@ -28,4 +30,6 @@ export const lists = {
   DocumentSection,
   DocumentsPage,
   Zipcode,
+  LandingPage,
+  Category,
 }


### PR DESCRIPTION
# SC-2599

Related PR: https://github.com/USSF-ORBIT/ussf-portal-client/pull/1128

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

**Note to self: This branch contains WIP commits!! UNWIP THEM.**

This is a research branch **only** and should not be merged in. The migrations are messy and experimental, the custom fields have lots of angry lint errors, etc. 

BUT. It does work as expected, and it's necessary to create a landing page and see the front-end spike in the related PR.

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-client
yarn dev
```

Login to the cms http://localhost:3001

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
