### PR TITLE
feat: Allow only published articles to link to a landing page

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1186,12 +1186,14 @@ type FilteredArticles {
   slug: String
   preview: String
   publishedDate: String
+  status: String
   labels: [ArticleLabel]
 }
 
 type ArticleLabel {
   id: String
   name: String
+  type: String
 }
 
 input LandingPageWhereUniqueInput {

--- a/src/lists/LandingPage.ts
+++ b/src/lists/LandingPage.ts
@@ -139,7 +139,8 @@ const LandingPage = list(
               slug: string
               preview: string
               publishedDate: string
-              labels: { id: string; name: string }[]
+              status: string
+              labels: { id: string; name: string; type: string }[]
             }>()({
               name: 'FilteredArticles',
               fields: {
@@ -148,13 +149,19 @@ const LandingPage = list(
                 slug: graphql.field({ type: graphql.String }),
                 preview: graphql.field({ type: graphql.String }),
                 publishedDate: graphql.field({ type: graphql.String }),
+                status: graphql.field({ type: graphql.String }),
                 labels: graphql.field({
                   type: graphql.list(
-                    graphql.object<{ id: string; name: string }>()({
+                    graphql.object<{
+                      id: string
+                      name: string
+                      type: string
+                    }>()({
                       name: 'ArticleLabel',
                       fields: {
                         id: graphql.field({ type: graphql.String }),
                         name: graphql.field({ type: graphql.String }),
+                        type: graphql.field({ type: graphql.String }),
                       },
                     })
                   ),
@@ -175,8 +182,12 @@ const LandingPage = list(
                 category: {
                   equals: ARTICLE_CATEGORIES.LANDING_PAGE,
                 },
+                status: {
+                  equals: 'Published',
+                },
               },
-              query: 'id title slug preview publishedDate labels { id name }',
+              query:
+                'id title slug preview publishedDate status labels { id name type }',
             })
 
             return articles.map((article) => ({
@@ -185,6 +196,7 @@ const LandingPage = list(
               slug: article.slug,
               preview: article.preview,
               publishedDate: article.publishedDate,
+              status: article.status,
               labels: article.labels,
             }))
           },


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
A follow up to https://github.com/USSF-ORBIT/ussf-portal-cms/pull/395 that:
- Adds the `status` field to the returned articles of a landing page
- Adds the `type` field for `labels` that are associated with an article
- Only allows published articles to link to a landing page
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Create a landing page to test, then:
- Create two articles: one published, and one in draft.
- Give the articles the same Tag, and associate that Tag with the landing page
- Verify that you can only see the published article linked on the landing page
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-client
yarn dev
```

Login to the cms http://localhost:3001

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
