### PR TITLE
feat: Managers can update existing landing pages

### DIFF
--- a/src/lists/LandingPage.test.ts
+++ b/src/lists/LandingPage.test.ts
@@ -1,0 +1,245 @@
+import { KeystoneContext } from '@keystone-6/core/types'
+import { configTestEnv } from '../testHelpers'
+
+describe('LandingPage', () => {
+  let adminContext: KeystoneContext
+  let userContext: KeystoneContext
+  let authorContext: KeystoneContext
+  let managerContext: KeystoneContext
+
+  const landingPageQuery = `id pageTitle slug`
+
+  // Set up test environment, seed data, and return contexts
+  beforeAll(
+    async () =>
+      ({ adminContext, userContext, authorContext, managerContext } =
+        await configTestEnv())
+  )
+
+  describe('access control', () => {
+    describe('as an admin user', () => {
+      test('can create a landing page', async () => {
+        const data = {
+          pageTitle: 'Test Landing Page',
+          slug: 'test-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+          query: landingPageQuery,
+        })
+
+        expect(landingPage.id).toBeTruthy()
+        expect(landingPage.pageTitle).toEqual('Test Landing Page')
+      })
+
+      test('can update a landing page', async () => {
+        const data = {
+          pageTitle: 'Update Landing Page',
+          slug: 'update-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        const updatedLandingPage =
+          await adminContext.query.LandingPage.updateOne({
+            where: { id: landingPage.id },
+            data: {
+              pageTitle: 'Updated Test Landing Page',
+            },
+            query: landingPageQuery,
+          })
+
+        expect(updatedLandingPage.pageTitle).toEqual(
+          'Updated Test Landing Page'
+        )
+      })
+
+      test('can delete a landing page', async () => {
+        const data = {
+          pageTitle: 'Delete Landing Page',
+          slug: 'delete-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        const deletedLandingPage =
+          await adminContext.query.LandingPage.deleteOne({
+            where: { id: landingPage.id },
+            query: landingPageQuery,
+          })
+
+        expect(deletedLandingPage?.id).toEqual(landingPage.id)
+      })
+    })
+
+    describe('as a non-admin user with the Manager role', () => {
+      test('unable to create a landing page', async () => {
+        const data = {
+          pageTitle: 'Test Landing Page',
+          slug: 'test-landing-page',
+        }
+
+        await expect(async () => {
+          await managerContext.query.LandingPage.createOne({
+            data,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+
+      test('unable to delete a landing page', async () => {
+        const data = {
+          pageTitle: 'Manager Delete Landing Page',
+          slug: 'manager-delete-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        await expect(async () => {
+          await managerContext.query.LandingPage.deleteOne({
+            where: { id: landingPage.id },
+            query: landingPageQuery,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+
+      test('can update a landing page', async () => {
+        const data = {
+          pageTitle: 'Manager Update Landing Page',
+          slug: 'manager-update-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        const updatedLandingPage =
+          await managerContext.query.LandingPage.updateOne({
+            where: { id: landingPage.id },
+            data: {
+              pageTitle: 'Manager Updated Test Landing Page',
+            },
+            query: landingPageQuery,
+          })
+
+        expect(updatedLandingPage.pageTitle).toEqual(
+          'Manager Updated Test Landing Page'
+        )
+      })
+    })
+
+    describe('as a non-admin user with the Author role', () => {
+      test('unable to create a landing page', async () => {
+        const data = {
+          pageTitle: 'Test Landing Page',
+          slug: 'test-landing-page',
+        }
+
+        await expect(async () => {
+          await authorContext.query.LandingPage.createOne({
+            data,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+
+      test('unable to delete a landing page', async () => {
+        const data = {
+          pageTitle: 'Author Delete Landing Page',
+          slug: 'author-delete-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        await expect(async () => {
+          await authorContext.query.LandingPage.deleteOne({
+            where: { id: landingPage.id },
+            query: landingPageQuery,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+
+      test('unable to update a landing page', async () => {
+        const data = {
+          pageTitle: 'Author Update Landing Page',
+          slug: 'author-update-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        await expect(async () => {
+          await authorContext.query.LandingPage.updateOne({
+            where: { id: landingPage.id },
+            data: {
+              pageTitle: 'Author Updated Test Landing Page',
+            },
+            query: landingPageQuery,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+    })
+
+    describe('as a non-admin user with the User role', () => {
+      test('unable to create a landing page', async () => {
+        const data = {
+          pageTitle: 'Test Landing Page',
+          slug: 'test-landing-page',
+        }
+
+        await expect(async () => {
+          await userContext.query.LandingPage.createOne({
+            data,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+
+      test('unable to delete a landing page', async () => {
+        const data = {
+          pageTitle: 'User Delete Landing Page',
+          slug: 'user-delete-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        await expect(async () => {
+          await userContext.query.LandingPage.deleteOne({
+            where: { id: landingPage.id },
+            query: landingPageQuery,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+
+      test('unable to update a landing page', async () => {
+        const data = {
+          pageTitle: 'User Update Landing Page',
+          slug: 'user-update-landing-page',
+        }
+
+        const landingPage = await adminContext.query.LandingPage.createOne({
+          data,
+        })
+
+        await expect(async () => {
+          await userContext.query.LandingPage.updateOne({
+            where: { id: landingPage.id },
+            data: {
+              pageTitle: 'User Updated Test Landing Page',
+            },
+            query: landingPageQuery,
+          })
+        }).rejects.toThrow('Access denied')
+      })
+    })
+  })
+})

--- a/src/lists/LandingPage.ts
+++ b/src/lists/LandingPage.ts
@@ -2,7 +2,7 @@ import { graphql, list } from '@keystone-6/core'
 import { relationship, text, virtual } from '@keystone-6/core/fields'
 import { withTracking } from '../util/tracking'
 import { slugify } from '../util/formatting'
-import { isAdmin } from '../util/access'
+import { isAdmin, canUpdateLandingPage } from '../util/access'
 import { ARTICLE_CATEGORIES } from './Article'
 // NOTE:
 // Disable the warning, this regex is only run after checking the max length
@@ -19,11 +19,11 @@ const LandingPage = list(
       operation: {
         create: isAdmin,
         query: () => true,
-        update: isAdmin,
+        update: canUpdateLandingPage,
         delete: isAdmin,
       },
       filter: {
-        update: isAdmin,
+        update: canUpdateLandingPage,
         delete: isAdmin,
       },
     },

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -205,3 +205,10 @@ export const documentPageItemView: ItemViewFn = ({ session }) => {
 
   return 'read'
 }
+
+/* Landing Page helpers */
+export const canUpdateLandingPage: OperationAccessFn = ({ session }) => {
+  if (session?.isAdmin || session?.role === USER_ROLES.MANAGER) return true
+
+  return false
+}


### PR DESCRIPTION
# SC-2705

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
- CMS Managers can update existing landing pages
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
A CMS Manager should be able to update an existing landing page. They **can't create or delete a landing page**.

When reviewing, don't forget that you will need to log in with an admin and give another user the `Manager` role to test this properly.
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-client
yarn dev
```

Login to the cms http://localhost:3001

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
