### PR TITLE
feat: landing pages show in search results

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1544,6 +1544,7 @@ enum SearchResultType {
   Article
   Bookmark
   Documentation
+  LandingPage
 }
 
 interface SearchResultItem {
@@ -1574,6 +1575,14 @@ type ArticleResult implements SearchResultItem {
 }
 
 type DocumentationResult implements SearchResultItem {
+  id: String!
+  title: String!
+  type: SearchResultType!
+  preview: String!
+  permalink: String!
+}
+
+type LandingPageResult implements SearchResultItem {
   id: String!
   title: String!
   type: SearchResultType!

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -5,7 +5,6 @@ import {
   publishedArticleData,
   searchTermArticleData,
   publishedLandingPageData,
-  draftLandingPageData,
   surf,
   orders,
   testArticles,

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -25,6 +25,9 @@ type SearchResults = {
   search: []
 }
 
+// Set the portal url to a test url for expectations
+process.env.PORTAL_URL = 'https://example.com'
+
 describe('Search Resolver', () => {
   // Define the search query we'll use in every request
   const searchQuery = `
@@ -84,7 +87,7 @@ describe('Search Resolver', () => {
         expect.objectContaining({
           __typename: 'ArticleResult',
           title: searchTermArticleData.title,
-          permalink: searchTermArticleData.slug,
+          permalink: `${process.env.PORTAL_URL}/articles/${searchTermArticleData.slug}`,
           preview: searchTermArticleData.preview,
           date: expect.any(String),
         }),
@@ -176,7 +179,7 @@ describe('Search Resolver', () => {
               type: publishedArticleData.labels.create.type,
             },
           ],
-          permalink: publishedArticleData.slug,
+          permalink: `${process.env.PORTAL_URL}/articles/${publishedArticleData.slug}`,
           preview: publishedArticleData.preview,
           tags: [
             {
@@ -268,7 +271,7 @@ describe('Search Resolver', () => {
         expect.objectContaining({
           __typename: 'ArticleResult',
           title: publishedArticleData.title,
-          permalink: publishedArticleData.slug,
+          permalink: `${process.env.PORTAL_URL}/articles/${publishedArticleData.slug}`,
           preview: publishedArticleData.preview,
           labels: [
             {

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -502,7 +502,7 @@ describe('Search Resolver', () => {
 
   describe('landing page search', () => {
     test('find by pageTitle', async () => {
-      const searchResults = await sudoContext.graphql.run({
+      const searchResults: SearchResults = await sudoContext.graphql.run({
         query: searchQuery,
         variables: {
           query: publishedLandingPageData.pageTitle,
@@ -512,17 +512,19 @@ describe('Search Resolver', () => {
       const results = searchResults.search
 
       expect(results).toHaveLength(4)
-      expect(results[3]).toEqual(
-        expect.objectContaining({
-          __typename: 'LandingPageResult',
-          title: publishedLandingPageData.pageTitle,
-          permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
-          preview: publishedLandingPageData.pageDescription,
-        })
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            __typename: 'LandingPageResult',
+            title: publishedLandingPageData.pageTitle,
+            permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
+            preview: publishedLandingPageData.pageDescription,
+          }),
+        ])
       )
     })
     test('find by pageDescription', async () => {
-      const searchResults = await sudoContext.graphql.run({
+      const searchResults: SearchResults = await sudoContext.graphql.run({
         query: searchQuery,
         variables: {
           query: publishedLandingPageData.pageDescription,
@@ -532,17 +534,19 @@ describe('Search Resolver', () => {
       const results = searchResults.search
 
       expect(results).toHaveLength(4)
-      expect(results[3]).toEqual(
-        expect.objectContaining({
-          __typename: 'LandingPageResult',
-          title: publishedLandingPageData.pageTitle,
-          permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
-          preview: publishedLandingPageData.pageDescription,
-        })
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            __typename: 'LandingPageResult',
+            title: publishedLandingPageData.pageTitle,
+            permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
+            preview: publishedLandingPageData.pageDescription,
+          }),
+        ])
       )
     })
     test('find by slug', async () => {
-      const searchResults = await sudoContext.graphql.run({
+      const searchResults: SearchResults = await sudoContext.graphql.run({
         query: searchQuery,
         variables: {
           query: publishedLandingPageData.slug,
@@ -552,17 +556,19 @@ describe('Search Resolver', () => {
       const results = searchResults.search
 
       expect(results).toHaveLength(3)
-      expect(results[2]).toEqual(
-        expect.objectContaining({
-          __typename: 'LandingPageResult',
-          title: publishedLandingPageData.pageTitle,
-          permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
-          preview: publishedLandingPageData.pageDescription,
-        })
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            __typename: 'LandingPageResult',
+            title: publishedLandingPageData.pageTitle,
+            permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
+            preview: publishedLandingPageData.pageDescription,
+          }),
+        ])
       )
     })
     test('find by articleTag', async () => {
-      const searchResults = await sudoContext.graphql.run({
+      const searchResults: SearchResults = await sudoContext.graphql.run({
         query: searchQuery,
         variables: {
           query: `tag:"${publishedLandingPageData.articleTag.create.name}"`,
@@ -572,13 +578,15 @@ describe('Search Resolver', () => {
       const results = searchResults.search
 
       expect(results).toHaveLength(1)
-      expect(results[0]).toEqual(
-        expect.objectContaining({
-          __typename: 'LandingPageResult',
-          title: publishedLandingPageData.pageTitle,
-          permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
-          preview: publishedLandingPageData.pageDescription,
-        })
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            __typename: 'LandingPageResult',
+            title: publishedLandingPageData.pageTitle,
+            permalink: `${process.env.PORTAL_URL}/landing/${publishedLandingPageData.slug}`,
+            preview: publishedLandingPageData.pageDescription,
+          }),
+        ])
       )
     })
   })

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -165,16 +165,20 @@ export const extendGraphqlSchema = (baseSchema: GraphQLSchema) =>
                   await prisma.article.findMany({
                     ...articleQuery,
                   })
-                ).map((article: ArticleQueryResult) => ({
-                  id: article.id,
-                  type: 'Article',
-                  title: article.title,
-                  permalink: article.slug,
-                  preview: article.preview,
-                  labels: article.labels,
-                  tags: article.tags,
-                  date: article.publishedDate?.toISOString(),
-                }))
+                ).map((article: ArticleQueryResult) => {
+                  // TODO: need to handle landing page articles differently here
+                  const permalink = `${process.env.PORTAL_URL}/articles/${article.slug}`
+                  return {
+                    id: article.id,
+                    type: 'Article',
+                    title: article.title,
+                    permalink: permalink,
+                    preview: article.preview,
+                    labels: article.labels,
+                    tags: article.tags,
+                    date: article.publishedDate?.toISOString(),
+                  }
+                })
               }
 
               if (c[DATA_TABLES.BOOKMARK]) {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -16,6 +16,7 @@ import {
   buildBookmarkQuery,
   buildDocumentQuery,
   buildDocumentationPageQuery,
+  buildLandingPageQuery,
 } from './search'
 
 // typeDefs for custom functionality
@@ -251,23 +252,20 @@ export const extendGraphqlSchema = (baseSchema: GraphQLSchema) =>
               }
 
               if (c[DATA_TABLES.LANDING_PAGE]) {
-                // FIX: permalink for landing page needs to be consturcted like we do for articles
                 landingPageResults = (
                   await prisma.landingPage.findMany({
-                    where: {
-                      pageTitle: {
-                        search: terms,
-                        mode: 'insensitive',
-                      },
-                    },
+                    ...buildLandingPageQuery(terms, tags),
                   })
-                ).map((landingPage: LandingPageSearchResult) => ({
-                  id: landingPage.id,
-                  type: 'LandingPage',
-                  title: landingPage.pageTitle,
-                  permalink: 'landingPage.permalink',
-                  preview: landingPage.pageDescription,
-                }))
+                ).map((landingPage: LandingPageSearchResult) => {
+                  const permalink = `${process.env.PORTAL_URL}/landing/${landingPage.slug}`
+                  return {
+                    id: landingPage.id,
+                    type: 'LandingPage',
+                    title: landingPage.pageTitle,
+                    permalink: permalink,
+                    preview: landingPage.pageDescription,
+                  }
+                })
               }
             })
           )

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,5 +1,9 @@
 import { DateTime } from 'luxon'
-import type { ParsedSearchQuery, ArticleQuery } from '../../types'
+import type {
+  ParsedSearchQuery,
+  ArticleQuery,
+  LandingPageQuery,
+} from '../../types'
 
 export const buildBookmarkQuery = (terms?: string) => ({
   where: {
@@ -181,6 +185,74 @@ export const buildDocumentQuery = (terms?: string) => ({
     ],
   },
 })
+
+export const buildLandingPageQuery = (terms?: string, tags?: string[]) => {
+  // Building blocks of the LandingPage query
+  // We can have tags, labels, terms, or any combination of the three
+  const tagsQuery = {
+    articleTag: {
+      some: {
+        name: {
+          in: tags,
+          mode: 'insensitive',
+        },
+      },
+    },
+  }
+
+  const termsQuery = {
+    OR: [
+      {
+        pageTitle: {
+          search: terms,
+          mode: 'insensitive',
+        },
+      },
+      {
+        pageDescription: {
+          search: terms,
+          mode: 'insensitive',
+        },
+      },
+      {
+        slug: {
+          search: terms,
+          mode: 'insensitive',
+        },
+      },
+    ],
+  }
+
+  // Establish the base query
+  const query: LandingPageQuery = {
+    where: {
+      status: 'Published',
+      publishedDate: {
+        lte: DateTime.now().toJSDate(),
+      },
+    },
+
+    include: {
+      articleTag: true,
+    },
+  }
+
+  if (terms && terms.length > 0) {
+    query.where.AND = [termsQuery, { OR: [] }]
+  } else {
+    query.where.OR = []
+  }
+
+  if (tags && tags.length > 0) {
+    if (terms) {
+      query.where.AND?.[1].OR?.push(tagsQuery)
+    } else {
+      query.where.OR?.push(tagsQuery)
+    }
+  }
+
+  return query
+}
 
 export const parseSearchQuery = (query: string): ParsedSearchQuery => {
   const tags: string[] = []

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -191,7 +191,7 @@ export const buildLandingPageQuery = (terms?: string, tags?: string[]) => {
   // We can have tags, labels, terms, or any combination of the three
   const tagsQuery = {
     articleTag: {
-      some: {
+      is: {
         name: {
           in: tags,
           mode: 'insensitive',

--- a/src/testData.ts
+++ b/src/testData.ts
@@ -92,3 +92,43 @@ export const testArticles = [
   searchTermArticleData,
   publishedArticleWithMultipleTagsData,
 ]
+
+// Landing Pages
+export const publishedLandingPageData = {
+  pageTitle: 'Published Landing Page',
+  slug: 'published-landing-page',
+  pageDescription: 'A published landing page.',
+  status: 'Published',
+  publishedDate: DateTime.now().toISO(),
+  articleTag: { create: { name: 'Test Landing Page Tag' } },
+}
+
+export const futurePublishedLandingPageData = {
+  pageTitle: 'Future Published Landing Page',
+  slug: 'future-published-landing-page',
+  pageDescription: 'A soon to be published landing page.',
+  status: 'Published',
+  publishedDate: DateTime.now().plus({ week: 1 }).toISO(),
+}
+
+export const draftLandingPageData = {
+  pageTitle: 'Draft Landing Page',
+  slug: 'draft-landing-page',
+  pageDescription: 'A draft landing page.',
+  status: 'Draft',
+}
+
+export const archivedLandingPageData = {
+  pageTitle: 'Archived Landing Page',
+  slug: 'archived-landing-page',
+  pageDescription: 'An archived landing page.',
+  status: 'Archived',
+  archivedDate: DateTime.now().toISO(),
+}
+
+export const testLandingPages = [
+  publishedLandingPageData,
+  futurePublishedLandingPageData,
+  draftLandingPageData,
+  archivedLandingPageData,
+]

--- a/types.ts
+++ b/types.ts
@@ -96,6 +96,14 @@ export type DocumentationSearchResult = {
   permalink: string
 }
 
+export type LandingPageSearchResult = {
+  id: string
+  type: 'LandingPage'
+  title: string
+  preview: string
+  permalink: string
+}
+
 // Query sent to the CMS database
 export type ArticleQuery = {
   where: {

--- a/types.ts
+++ b/types.ts
@@ -99,9 +99,25 @@ export type DocumentationSearchResult = {
 export type LandingPageSearchResult = {
   id: string
   type: 'LandingPage'
-  title: string
-  preview: string
+  pageTitle: string
+  pageDescription: string
   permalink: string
+  slug: string
+}
+
+// Query sent to the CMS database
+export type LandingPageQuery = {
+  where: {
+    status: string
+    publishedDate: {
+      lte: Date
+    }
+    OR?: any[]
+    AND?: [{ OR?: any[] }, { OR?: any[] }]
+  }
+  include: {
+    articleTag: boolean
+  }
 }
 
 // Query sent to the CMS database


### PR DESCRIPTION
# SC-2635

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->

- return permalink for articles. (NOTE: This currently assumes not landing page articles)
- return landing page if terms are a match in pageTitle, pageDescription, slug, or tags

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

- https://github.com/USSF-ORBIT/ussf-portal/pull/353
- https://github.com/USSF-ORBIT/ussf-portal-client/pull/1190

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-client
yarn dev
```

Login to the cms http://localhost:3001

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
