### PR TITLE
feat: Managers can create landing pages

### DIFF
--- a/src/lists/LandingPage.test.ts
+++ b/src/lists/LandingPage.test.ts
@@ -277,17 +277,19 @@ describe('LandingPage', () => {
     })
 
     describe('as a non-admin user with the Manager role', () => {
-      test('unable to create a landing page', async () => {
+      test('can create a landing page', async () => {
         const data = {
-          pageTitle: 'Test Landing Page',
-          slug: 'test-landing-page',
+          pageTitle: 'Manager Landing Page',
+          slug: 'manager-landing-page',
         }
 
-        await expect(async () => {
-          await managerContext.query.LandingPage.createOne({
-            data,
-          })
-        }).rejects.toThrow('Access denied')
+        const landingPage = await managerContext.query.LandingPage.createOne({
+          data,
+          query: landingPageQuery,
+        })
+
+        expect(landingPage.id).toBeTruthy()
+        expect(landingPage.pageTitle).toEqual('Manager Landing Page')
       })
 
       test('unable to delete a landing page', async () => {

--- a/src/lists/LandingPage.ts
+++ b/src/lists/LandingPage.ts
@@ -11,6 +11,7 @@ import { withTracking } from '../util/tracking'
 import { slugify } from '../util/formatting'
 import {
   isAdmin,
+  canCreateLandingPage,
   canUpdateLandingPage,
   canPublishArchiveLanding,
   landingStatusView,
@@ -30,7 +31,7 @@ const LandingPage = list(
   withTracking({
     access: {
       operation: {
-        create: isAdmin,
+        create: canCreateLandingPage,
         query: () => true,
         update: canUpdateLandingPage,
         delete: isAdmin,
@@ -41,8 +42,8 @@ const LandingPage = list(
       },
     },
     ui: {
-      hideCreate: () => false,
-      hideDelete: () => false,
+      hideCreate: ({ session }) => !canCreateLandingPage({ session }),
+      hideDelete: ({ session }) => !isAdmin({ session }),
       label: 'Landing Page',
       createView: {
         defaultFieldMode: 'edit',

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -219,6 +219,12 @@ export const documentPageItemView: ItemViewFn = ({ session }) => {
 }
 
 /* Landing Page helpers */
+export const canCreateLandingPage: OperationAccessFn = ({ session }) => {
+  if (session?.isAdmin || session?.role === USER_ROLES.MANAGER) return true
+
+  return false
+}
+
 export const canUpdateLandingPage: OperationAccessFn = ({ session }) => {
   if (session?.isAdmin || session?.role === USER_ROLES.MANAGER) return true
 


### PR DESCRIPTION
# SC-3012

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
- Users with a Manager role can create landing pages
- Hide create/delete button for landing pages from users without the appropriate permissions
- Update tests
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
When testing, remember that you will need to give a CMS user the Manager role using the `cmsadmin` account
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-client
yarn dev
```

Login to the cms http://localhost:3001

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
