### PR TITLE
feat: Manager role can create/update Collections and Bookmarks

### DIFF
--- a/src/lists/Bookmark.ts
+++ b/src/lists/Bookmark.ts
@@ -1,27 +1,29 @@
 import { list } from '@keystone-6/core'
 import { relationship, text } from '@keystone-6/core/fields'
 
-import { isAdmin, editReadAdminUI } from '../util/access'
+import {
+  canCreateBookmark,
+  canUpdateBookmark,
+  bookmarkCreateView,
+} from '../util/access'
 import { withTracking } from '../util/tracking'
 
 const Bookmark = list(
   withTracking({
-    // Admin can create and update bookmarks
-    // Users can view all bookmarks
     access: {
       operation: {
-        create: isAdmin,
+        create: canCreateBookmark,
         query: () => true,
-        update: isAdmin,
+        update: canUpdateBookmark,
         delete: () => false,
       },
     },
 
     ui: {
-      hideCreate: ({ session }) => !isAdmin({ session }),
+      hideCreate: ({ session }) => !canCreateBookmark({ session }),
       hideDelete: true,
       itemView: {
-        defaultFieldMode: editReadAdminUI,
+        defaultFieldMode: bookmarkCreateView,
       },
     },
 

--- a/src/lists/Collection.ts
+++ b/src/lists/Collection.ts
@@ -1,16 +1,21 @@
 import { list } from '@keystone-6/core'
 import { checkbox, relationship, text } from '@keystone-6/core/fields'
 
-import { isAdmin, editReadAdminUI } from '../util/access'
+import {
+  isAdmin,
+  editReadAdminUI,
+  canCreateCollection,
+  canUpdateCollection,
+} from '../util/access'
 import { withTracking } from '../util/tracking'
 
 const Collection = list(
   withTracking({
     access: {
       operation: {
-        create: isAdmin,
+        create: canCreateCollection,
         query: () => true,
-        update: isAdmin,
+        update: canUpdateCollection,
         delete: () => false,
       },
     },

--- a/src/lists/Collection.ts
+++ b/src/lists/Collection.ts
@@ -2,10 +2,9 @@ import { list } from '@keystone-6/core'
 import { checkbox, relationship, text } from '@keystone-6/core/fields'
 
 import {
-  isAdmin,
-  editReadAdminUI,
   canCreateCollection,
   canUpdateCollection,
+  collectionCreateView,
 } from '../util/access'
 import { withTracking } from '../util/tracking'
 
@@ -21,10 +20,10 @@ const Collection = list(
     },
 
     ui: {
-      hideCreate: ({ session }) => !isAdmin({ session }),
+      hideCreate: ({ session }) => !canCreateCollection({ session }),
       hideDelete: true,
       itemView: {
-        defaultFieldMode: editReadAdminUI,
+        defaultFieldMode: collectionCreateView,
       },
     },
 

--- a/src/util/access.test.ts
+++ b/src/util/access.test.ts
@@ -18,6 +18,12 @@ import {
   articleCreateView,
   articleItemView,
   articleStatusView,
+  canCreateCollection,
+  canUpdateCollection,
+  collectionCreateView,
+  canCreateBookmark,
+  canUpdateBookmark,
+  bookmarkCreateView,
   canCreateOrUpdateDocument,
   canUpdateDocument,
   canDeleteDocument,
@@ -160,6 +166,117 @@ describe('userItemView', () => {
   })
 })
 
+/* Collection Access */
+describe('canCreateCollection', () => {
+  it('returns true if the logged in user is an admin', () => {
+    expect(canCreateCollection({ session: testAdminSession })).toBe(true)
+  })
+  it('returns true if the logged in user is a manager', () => {
+    expect(canCreateCollection({ session: testManagerSession })).toBe(true)
+  })
+  it('returns false if the logged in user is an author', () => {
+    expect(canCreateCollection({ session: testAuthorSession })).toBe(false)
+  })
+  it('returns false if the logged in user is a user', () => {
+    expect(canCreateCollection({ session: testUserSession })).toBe(false)
+  })
+  it('returns false if there is no logged in user', () => {
+    expect(canCreateCollection({})).toBe(false)
+  })
+})
+
+describe('canUpdateCollection', () => {
+  it('returns true if the logged in user is an admin', () => {
+    expect(canUpdateCollection({ session: testAdminSession })).toBe(true)
+  })
+  it('returns true if the logged in user is a manager', () => {
+    expect(canUpdateCollection({ session: testManagerSession })).toBe(true)
+  })
+  it('returns false if the logged in user is an author', () => {
+    expect(canUpdateCollection({ session: testAuthorSession })).toBe(false)
+  })
+  it('returns false if the logged in user is a user', () => {
+    expect(canUpdateCollection({ session: testUserSession })).toBe(false)
+  })
+  it('returns false if there is no logged in user', () => {
+    expect(canUpdateCollection({})).toBe(false)
+  })
+})
+
+describe('collectionCreateView', () => {
+  it('returns edit if the logged in user is an admin', () => {
+    expect(collectionCreateView({ session: testAdminSession })).toBe('edit')
+  })
+  it('returns edit if the logged in user is a manager', () => {
+    expect(collectionCreateView({ session: testManagerSession })).toBe('edit')
+  })
+  it('returns hidden if the logged in user is an author', () => {
+    expect(collectionCreateView({ session: testAuthorSession })).toBe('hidden')
+  })
+  it('returns hidden if the logged in user is a user', () => {
+    expect(collectionCreateView({ session: testUserSession })).toBe('hidden')
+  })
+  it('returns hidden if there is no logged in user', () => {
+    expect(collectionCreateView({})).toBe('hidden')
+  })
+})
+
+/* Bookmark Access */
+describe('canCreateBookmark', () => {
+  it('returns true if the logged in user is an admin', () => {
+    expect(canCreateBookmark({ session: testAdminSession })).toBe(true)
+  })
+  it('returns true if the logged in user is a manager', () => {
+    expect(canCreateBookmark({ session: testManagerSession })).toBe(true)
+  })
+  it('returns false if the logged in user is an author', () => {
+    expect(canCreateBookmark({ session: testAuthorSession })).toBe(false)
+  })
+  it('returns false if the logged in user is a user', () => {
+    expect(canCreateBookmark({ session: testUserSession })).toBe(false)
+  })
+  it('returns false if there is no logged in user', () => {
+    expect(canCreateBookmark({})).toBe(false)
+  })
+})
+
+describe('canUpdateBookmark', () => {
+  it('returns true if the logged in user is an admin', () => {
+    expect(canUpdateBookmark({ session: testAdminSession })).toBe(true)
+  })
+  it('returns true if the logged in user is a manager', () => {
+    expect(canUpdateBookmark({ session: testManagerSession })).toBe(true)
+  })
+  it('returns false if the logged in user is an author', () => {
+    expect(canUpdateBookmark({ session: testAuthorSession })).toBe(false)
+  })
+  it('returns false if the logged in user is a user', () => {
+    expect(canUpdateBookmark({ session: testUserSession })).toBe(false)
+  })
+  it('returns false if there is no logged in user', () => {
+    expect(canUpdateBookmark({})).toBe(false)
+  })
+})
+
+describe('bookmarkCreateView', () => {
+  it('returns edit if the logged in user is an admin', () => {
+    expect(bookmarkCreateView({ session: testAdminSession })).toBe('edit')
+  })
+  it('returns edit if the logged in user is a manager', () => {
+    expect(bookmarkCreateView({ session: testManagerSession })).toBe('edit')
+  })
+  it('returns hidden if the logged in user is an author', () => {
+    expect(bookmarkCreateView({ session: testAuthorSession })).toBe('hidden')
+  })
+  it('returns hidden if the logged in user is a user', () => {
+    expect(bookmarkCreateView({ session: testUserSession })).toBe('hidden')
+  })
+  it('returns hidden if there is no logged in user', () => {
+    expect(bookmarkCreateView({})).toBe('hidden')
+  })
+})
+
+/* Article Access */
 describe('canCreateArticle', () => {
   it('returns true if the logged in user is an admin', () => {
     expect(canCreateArticle({ session: testAdminSession })).toBe(true)

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -114,6 +114,9 @@ export const canUpdateCollection: OperationAccessFn = ({ session }) => {
   return session?.isAdmin || session?.role === USER_ROLES.MANAGER
 }
 
+export const collectionCreateView: CreateViewFn = ({ session }) =>
+  canCreateCollection({ session }) ? 'edit' : 'hidden'
+
 /** Article helpers */
 export const canCreateArticle: OperationAccessFn = ({ session }) => {
   return (

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -105,6 +105,15 @@ export const userItemView: ItemViewFn = ({ session, item }) => {
   return 'read'
 }
 
+/** Collection helpers */
+export const canCreateCollection: OperationAccessFn = ({ session }) => {
+  return session?.isAdmin || session?.role === USER_ROLES.MANAGER
+}
+
+export const canUpdateCollection: OperationAccessFn = ({ session }) => {
+  return session?.isAdmin || session?.role === USER_ROLES.MANAGER
+}
+
 /** Article helpers */
 export const canCreateArticle: OperationAccessFn = ({ session }) => {
   return (

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -117,6 +117,18 @@ export const canUpdateCollection: OperationAccessFn = ({ session }) => {
 export const collectionCreateView: CreateViewFn = ({ session }) =>
   canCreateCollection({ session }) ? 'edit' : 'hidden'
 
+/** Bookmark helpers */
+export const canCreateBookmark: OperationAccessFn = ({ session }) => {
+  return session?.isAdmin || session?.role === USER_ROLES.MANAGER
+}
+
+export const canUpdateBookmark: OperationAccessFn = ({ session }) => {
+  return session?.isAdmin || session?.role === USER_ROLES.MANAGER
+}
+
+export const bookmarkCreateView: CreateViewFn = ({ session }) =>
+  canCreateBookmark({ session }) ? 'edit' : 'hidden'
+
 /** Article helpers */
 export const canCreateArticle: OperationAccessFn = ({ session }) => {
   return (


### PR DESCRIPTION
# SC-3080

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Users with a Manager role can create and update Collections and Bookmakrs
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Log in to the CMS as a user with the Manager role and you should be able to create/update Collections and Bookmarks
- Remember that you will need to manually give a user the Manager role if you do not already have one locally
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-client
yarn dev
```

Login to the cms http://localhost:3001

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
