### PR TITLE
fix: allow admins and managers to delete bookmarks

### DIFF
--- a/src/lists/Bookmark.test.ts
+++ b/src/lists/Bookmark.test.ts
@@ -16,7 +16,7 @@ describe('Bookmark schema', () => {
   beforeAll(async () => ({ adminContext, userContext } = await configTestEnv()))
 
   describe('as an admin user', () => {
-    it('can create new bookmarks', async () => {
+    test('can create new bookmarks', async () => {
       const data = await adminContext.query.Bookmark.createOne({
         data: testBookmark,
         query: 'id url label description keywords createdAt updatedAt',
@@ -30,7 +30,7 @@ describe('Bookmark schema', () => {
       })
     })
 
-    it('can query all bookmarks', async () => {
+    test('can query all bookmarks', async () => {
       const data = await adminContext.query.Bookmark.findMany({
         query: 'id url label description keywords createdAt updatedAt',
       })
@@ -44,7 +44,7 @@ describe('Bookmark schema', () => {
       })
     })
 
-    it('can update a bookmark', async () => {
+    test('can update a bookmark', async () => {
       const existingBookmarks = await adminContext.query.Bookmark.findMany({
         query: 'id',
       })
@@ -69,23 +69,27 @@ describe('Bookmark schema', () => {
       expect(data.createdAt).not.toBe(data.updatedAt)
     })
 
-    it('cannot delete bookmarks', async () => {
-      const existingBookmarks = await adminContext.query.Bookmark.findMany({
-        query: 'id',
+    test('can delete bookmarks', async () => {
+      const bookmark = await adminContext.query.Bookmark.createOne({
+        data: { ...testBookmark, label: 'To be deleted' },
+        query: 'id url label description keywords createdAt updatedAt',
       })
 
-      expect(
-        adminContext.query.Bookmark.deleteOne({
-          where: { id: existingBookmarks[0].id },
-        })
-      ).rejects.toThrow(
-        'Access denied: You cannot delete that Bookmark - it may not exist'
-      )
+      await adminContext.query.Bookmark.deleteOne({
+        where: { id: bookmark.id },
+      })
+
+      const data = await adminContext.query.Bookmark.findOne({
+        where: { id: bookmark.id },
+        query: 'id url label description',
+      })
+
+      expect(data).toEqual(null)
     })
   })
 
   describe('as a non admin user', () => {
-    it('can query all bookmarks', async () => {
+    test('can query all bookmarks', async () => {
       const data = await userContext.query.Bookmark.findMany({
         query: 'id url label description keywords createdAt updatedAt',
       })
@@ -99,7 +103,7 @@ describe('Bookmark schema', () => {
       })
     })
 
-    it('cannot create bookmarks', async () => {
+    test('cannot create bookmarks', async () => {
       expect(
         userContext.query.Bookmark.createOne({
           data: testBookmark,
@@ -108,7 +112,7 @@ describe('Bookmark schema', () => {
       ).rejects.toThrow('Access denied: You cannot create that Bookmark')
     })
 
-    it('cannot update bookmarks', async () => {
+    test('cannot update bookmarks', async () => {
       const existingBookmarks = await userContext.query.Bookmark.findMany({
         query: 'id',
       })
@@ -126,7 +130,7 @@ describe('Bookmark schema', () => {
       )
     })
 
-    it('cannot delete bookmarks', async () => {
+    test('cannot delete bookmarks', async () => {
       const existingBookmarks = await userContext.query.Bookmark.findMany({
         query: 'id',
       })

--- a/src/lists/Bookmark.ts
+++ b/src/lists/Bookmark.ts
@@ -5,6 +5,7 @@ import {
   canCreateBookmark,
   canUpdateBookmark,
   bookmarkCreateView,
+  canDeleteBookmark,
 } from '../util/access'
 import { withTracking } from '../util/tracking'
 
@@ -15,13 +16,13 @@ const Bookmark = list(
         create: canCreateBookmark,
         query: () => true,
         update: canUpdateBookmark,
-        delete: () => false,
+        delete: canDeleteBookmark,
       },
     },
 
     ui: {
       hideCreate: ({ session }) => !canCreateBookmark({ session }),
-      hideDelete: true,
+      hideDelete: ({ session }) => !canDeleteBookmark({ session }),
       itemView: {
         defaultFieldMode: bookmarkCreateView,
       },

--- a/src/util/access.test.ts
+++ b/src/util/access.test.ts
@@ -23,6 +23,7 @@ import {
   collectionCreateView,
   canCreateBookmark,
   canUpdateBookmark,
+  canDeleteBookmark,
   bookmarkCreateView,
   canCreateOrUpdateDocument,
   canUpdateDocument,
@@ -35,23 +36,23 @@ import {
 } from './access'
 
 describe('isAdmin', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(
       isAdmin({
         session: testAdminSession,
       })
     ).toBe(true)
   })
-  it('returns false if the logged in user is not an admin', () => {
+  test('returns false if the logged in user is not an admin', () => {
     expect(isAdmin({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(isAdmin({})).toBe(false)
   })
 })
 
 describe('isAdminOrSelf', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(
       isAdminOrSelf({
         session: testAdminSession,
@@ -59,7 +60,7 @@ describe('isAdminOrSelf', () => {
     ).toBe(true)
   })
 
-  it('returns a filter on the logged in userId if not an admin', () => {
+  test('returns a filter on the logged in userId if not an admin', () => {
     expect(
       isAdminOrSelf({
         session: testUserSession,
@@ -71,46 +72,46 @@ describe('isAdminOrSelf', () => {
     })
   })
 
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(isAdminOrSelf({})).toBe(false)
   })
 })
 
 describe('showHideAdminUI', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(
       showHideAdminUI({
         session: testAdminSession,
       })
     ).toBe('edit')
   })
-  it('returns hidden if the logged in user is not an admin', () => {
+  test('returns hidden if the logged in user is not an admin', () => {
     expect(showHideAdminUI({ session: testUserSession })).toBe('hidden')
   })
-  it('returns hidden if there is no logged in user', () => {
+  test('returns hidden if there is no logged in user', () => {
     expect(showHideAdminUI({})).toBe('hidden')
   })
 })
 
 describe('editReadAdminUI', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(
       editReadAdminUI({
         session: testAdminSession,
       })
     ).toBe('edit')
   })
-  it('returns read if the logged in user is not an admin', () => {
+  test('returns read if the logged in user is not an admin', () => {
     expect(editReadAdminUI({ session: testUserSession })).toBe('read')
   })
 
-  it('returns read if there is no logged in user', () => {
+  test('returns read if there is no logged in user', () => {
     expect(editReadAdminUI({})).toBe('read')
   })
 })
 
 describe('userQueryFilter', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(
       userQueryFilter({
         session: testAdminSession,
@@ -118,14 +119,14 @@ describe('userQueryFilter', () => {
     ).toBe(true)
   })
 
-  it('returns true if the logged in user is an author', () => {
+  test('returns true if the logged in user is an author', () => {
     expect(userQueryFilter({ session: testAuthorSession })).toBe(true)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(userQueryFilter({ session: testManagerSession })).toBe(true)
   })
 
-  it('returns a filter on the logged in userId if not an admin, author, or manager', () => {
+  test('returns a filter on the logged in userId if not an admin, author, or manager', () => {
     expect(
       userQueryFilter({
         session: testUserSession,
@@ -137,17 +138,17 @@ describe('userQueryFilter', () => {
     })
   })
 
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(userQueryFilter({})).toBe(false)
   })
 })
 
 describe('userItemView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(userItemView({ session: testAdminSession })).toBe('edit')
   })
 
-  it('returns edit if the logged in user is the user', () => {
+  test('returns edit if the logged in user is the user', () => {
     expect(
       userItemView({
         session: testAuthorSession,
@@ -156,7 +157,7 @@ describe('userItemView', () => {
     ).toBe('edit')
   })
 
-  it('returns read if the logged in user is NOT the user', () => {
+  test('returns read if the logged in user is NOT the user', () => {
     expect(
       userItemView({
         session: testAuthorSession,
@@ -168,196 +169,214 @@ describe('userItemView', () => {
 
 /* Collection Access */
 describe('canCreateCollection', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canCreateCollection({ session: testAdminSession })).toBe(true)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canCreateCollection({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is an author', () => {
+  test('returns false if the logged in user is an author', () => {
     expect(canCreateCollection({ session: testAuthorSession })).toBe(false)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canCreateCollection({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canCreateCollection({})).toBe(false)
   })
 })
 
 describe('canUpdateCollection', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canUpdateCollection({ session: testAdminSession })).toBe(true)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canUpdateCollection({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is an author', () => {
+  test('returns false if the logged in user is an author', () => {
     expect(canUpdateCollection({ session: testAuthorSession })).toBe(false)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canUpdateCollection({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canUpdateCollection({})).toBe(false)
   })
 })
 
 describe('collectionCreateView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(collectionCreateView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(collectionCreateView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns hidden if the logged in user is an author', () => {
+  test('returns hidden if the logged in user is an author', () => {
     expect(collectionCreateView({ session: testAuthorSession })).toBe('hidden')
   })
-  it('returns hidden if the logged in user is a user', () => {
+  test('returns hidden if the logged in user is a user', () => {
     expect(collectionCreateView({ session: testUserSession })).toBe('hidden')
   })
-  it('returns hidden if there is no logged in user', () => {
+  test('returns hidden if there is no logged in user', () => {
     expect(collectionCreateView({})).toBe('hidden')
   })
 })
 
 /* Bookmark Access */
 describe('canCreateBookmark', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canCreateBookmark({ session: testAdminSession })).toBe(true)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canCreateBookmark({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is an author', () => {
+  test('returns false if the logged in user is an author', () => {
     expect(canCreateBookmark({ session: testAuthorSession })).toBe(false)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canCreateBookmark({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canCreateBookmark({})).toBe(false)
   })
 })
 
 describe('canUpdateBookmark', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canUpdateBookmark({ session: testAdminSession })).toBe(true)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canUpdateBookmark({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is an author', () => {
+  test('returns false if the logged in user is an author', () => {
     expect(canUpdateBookmark({ session: testAuthorSession })).toBe(false)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canUpdateBookmark({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canUpdateBookmark({})).toBe(false)
   })
 })
 
+describe('canDeleteBookmark', () => {
+  test('returns true if the logged in user is an admin', () => {
+    expect(canDeleteBookmark({ session: testAdminSession })).toBe(true)
+  })
+  test('returns true if the logged in user is a manager', () => {
+    expect(canDeleteBookmark({ session: testManagerSession })).toBe(true)
+  })
+  test('returns false if the logged in user is an author', () => {
+    expect(canDeleteBookmark({ session: testAuthorSession })).toBe(false)
+  })
+  test('returns false if the logged in user is a user', () => {
+    expect(canDeleteBookmark({ session: testUserSession })).toBe(false)
+  })
+  test('returns false if there is no logged in user', () => {
+    expect(canDeleteBookmark({})).toBe(false)
+  })
+})
+
 describe('bookmarkCreateView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(bookmarkCreateView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(bookmarkCreateView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns hidden if the logged in user is an author', () => {
+  test('returns hidden if the logged in user is an author', () => {
     expect(bookmarkCreateView({ session: testAuthorSession })).toBe('hidden')
   })
-  it('returns hidden if the logged in user is a user', () => {
+  test('returns hidden if the logged in user is a user', () => {
     expect(bookmarkCreateView({ session: testUserSession })).toBe('hidden')
   })
-  it('returns hidden if there is no logged in user', () => {
+  test('returns hidden if there is no logged in user', () => {
     expect(bookmarkCreateView({})).toBe('hidden')
   })
 })
 
 /* Article Access */
 describe('canCreateArticle', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canCreateArticle({ session: testAdminSession })).toBe(true)
   })
-  it('returns true if the logged in user is an author', () => {
+  test('returns true if the logged in user is an author', () => {
     expect(canCreateArticle({ session: testAuthorSession })).toBe(true)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canCreateArticle({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canCreateArticle({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canCreateArticle({})).toBe(false)
   })
 })
 
 describe('canUpdateDeleteArticle', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canUpdateDeleteArticle({ session: testAdminSession })).toBe(true)
   })
-  it('returns a filter on the item id if the logged in user is an author', () => {
+  test('returns a filter on the item id if the logged in user is an author', () => {
     expect(
       canUpdateDeleteArticle({ session: testAuthorSession })
     ).toMatchObject({
       createdBy: { id: { equals: testAuthorSession.itemId } },
     })
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canUpdateDeleteArticle({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canUpdateDeleteArticle({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canUpdateDeleteArticle({})).toBe(false)
   })
 })
 
 describe('canPublishArchiveArticle', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canPublishArchiveArticle({ session: testAdminSession })).toBe(true)
   })
-  it('returns false if the logged in user is an author', () => {
+  test('returns false if the logged in user is an author', () => {
     expect(canPublishArchiveArticle({ session: testAuthorSession })).toBe(false)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canPublishArchiveArticle({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canPublishArchiveArticle({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canPublishArchiveArticle({})).toBe(false)
   })
 })
 
 describe('articleCreateView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(articleCreateView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is an author', () => {
+  test('returns edit if the logged in user is an author', () => {
     expect(articleCreateView({ session: testAuthorSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(articleCreateView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns hidden if the logged in user is a user', () => {
+  test('returns hidden if the logged in user is a user', () => {
     expect(articleCreateView({ session: testUserSession })).toBe('hidden')
   })
-  it('returns hidden if there is no logged in user', () => {
+  test('returns hidden if there is no logged in user', () => {
     expect(articleCreateView({})).toBe('hidden')
   })
 })
 
 describe('articleItemView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(articleItemView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is an author and the creator of the article', () => {
+  test('returns edit if the logged in user is an author and the creator of the article', () => {
     expect(
       articleItemView({
         session: testAuthorSession,
@@ -365,7 +384,7 @@ describe('articleItemView', () => {
       })
     ).toBe('edit')
   })
-  it('returns read if the logged in user is an author and NOT the creator of the article', () => {
+  test('returns read if the logged in user is an author and NOT the creator of the article', () => {
     expect(
       articleItemView({
         session: testAuthorSession,
@@ -374,41 +393,41 @@ describe('articleItemView', () => {
     ).toBe('read')
   })
 
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(articleItemView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns read if the logged in user is a user', () => {
+  test('returns read if the logged in user is a user', () => {
     expect(articleItemView({ session: testUserSession })).toBe('read')
   })
-  it('returns read if there is no logged in user', () => {
+  test('returns read if there is no logged in user', () => {
     expect(articleItemView({})).toBe('read')
   })
 })
 
 describe('articleStatusView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(articleStatusView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns read if the logged in user is an author', () => {
+  test('returns read if the logged in user is an author', () => {
     expect(articleStatusView({ session: testAuthorSession })).toBe('read')
   })
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(articleStatusView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns read if the logged in user is a user', () => {
+  test('returns read if the logged in user is a user', () => {
     expect(articleStatusView({ session: testUserSession })).toBe('read')
   })
-  it('returns read if there is no logged in user', () => {
+  test('returns read if there is no logged in user', () => {
     expect(articleStatusView({})).toBe('read')
   })
 })
 
 /* Document Access */
 describe('documentItemView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(documentItemView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is an author and the creator of the article', () => {
+  test('returns edit if the logged in user is an author and the creator of the article', () => {
     expect(
       documentItemView({
         session: testAuthorSession,
@@ -416,7 +435,7 @@ describe('documentItemView', () => {
       })
     ).toBe('edit')
   })
-  it('returns read if the logged in user is an author and NOT the creator of the article', () => {
+  test('returns read if the logged in user is an author and NOT the creator of the article', () => {
     expect(
       documentItemView({
         session: testAuthorSession,
@@ -425,145 +444,145 @@ describe('documentItemView', () => {
     ).toBe('read')
   })
 
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(documentItemView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns read if the logged in user is a user', () => {
+  test('returns read if the logged in user is a user', () => {
     expect(documentItemView({ session: testUserSession })).toBe('read')
   })
-  it('returns read if there is no logged in user', () => {
+  test('returns read if there is no logged in user', () => {
     expect(documentItemView({})).toBe('read')
   })
 })
 
 describe('documentCreateView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(documentCreateView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is an author', () => {
+  test('returns edit if the logged in user is an author', () => {
     expect(documentCreateView({ session: testAuthorSession })).toBe('edit')
   })
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(documentCreateView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns hidden if the logged in user is a user', () => {
+  test('returns hidden if the logged in user is a user', () => {
     expect(documentCreateView({ session: testUserSession })).toBe('hidden')
   })
-  it('returns hidden if there is no logged in user', () => {
+  test('returns hidden if there is no logged in user', () => {
     expect(documentCreateView({})).toBe('hidden')
   })
 })
 
 describe('documentPageCreateView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(documentPageCreateView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns hidden if the logged in user is an author', () => {
+  test('returns hidden if the logged in user is an author', () => {
     expect(documentPageCreateView({ session: testAuthorSession })).toBe(
       'hidden'
     )
   })
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(documentPageCreateView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns hidden if the logged in user is a user', () => {
+  test('returns hidden if the logged in user is a user', () => {
     expect(documentPageCreateView({ session: testUserSession })).toBe('hidden')
   })
-  it('returns hidden if there is no logged in user', () => {
+  test('returns hidden if there is no logged in user', () => {
     expect(documentPageCreateView({})).toBe('hidden')
   })
 })
 
 describe('documentPageItemView', () => {
-  it('returns edit if the logged in user is an admin', () => {
+  test('returns edit if the logged in user is an admin', () => {
     expect(documentPageItemView({ session: testAdminSession })).toBe('edit')
   })
-  it('returns read if the logged in user is an author', () => {
+  test('returns read if the logged in user is an author', () => {
     expect(documentPageItemView({ session: testAuthorSession })).toBe('read')
   })
-  it('returns edit if the logged in user is a manager', () => {
+  test('returns edit if the logged in user is a manager', () => {
     expect(documentPageItemView({ session: testManagerSession })).toBe('edit')
   })
-  it('returns read if the logged in user is a user', () => {
+  test('returns read if the logged in user is a user', () => {
     expect(documentPageItemView({ session: testUserSession })).toBe('read')
   })
-  it('returns read if there is no logged in user', () => {
+  test('returns read if there is no logged in user', () => {
     expect(documentPageItemView({})).toBe('read')
   })
 })
 
 describe('canCreateOrUpdateDocument', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canCreateOrUpdateDocument({ session: testAdminSession })).toBe(true)
   })
-  it('returns true if the logged in user is an author', () => {
+  test('returns true if the logged in user is an author', () => {
     expect(canCreateOrUpdateDocument({ session: testAuthorSession })).toBe(true)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canCreateOrUpdateDocument({ session: testManagerSession })).toBe(
       true
     )
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canCreateOrUpdateDocument({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canCreateOrUpdateDocument({})).toBe(false)
   })
 })
 
 describe('canUpdateDocument filter', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canUpdateDocument({ session: testAdminSession })).toBe(true)
   })
-  it('returns a filter on the item id if the logged in user is an author', () => {
+  test('returns a filter on the item id if the logged in user is an author', () => {
     expect(canUpdateDocument({ session: testAuthorSession })).toMatchObject({
       createdBy: { id: { equals: testAuthorSession.itemId } },
     })
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canUpdateDeleteArticle({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canUpdateDeleteArticle({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canUpdateDeleteArticle({})).toBe(false)
   })
 })
 
 describe('canDeleteDocument', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canDeleteDocument({ session: testAdminSession })).toBe(true)
   })
-  it('returns false if the logged in user is an author', () => {
+  test('returns false if the logged in user is an author', () => {
     expect(canDeleteDocument({ session: testAuthorSession })).toBe(false)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canDeleteDocument({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canDeleteDocument({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canDeleteDocument({})).toBe(false)
   })
 })
 
 describe('canCreateDocumentPage', () => {
-  it('returns true if the logged in user is an admin', () => {
+  test('returns true if the logged in user is an admin', () => {
     expect(canCreateDocumentPage({ session: testAdminSession })).toBe(true)
   })
-  it('returns false if the logged in user is an author', () => {
+  test('returns false if the logged in user is an author', () => {
     expect(canCreateDocumentPage({ session: testAuthorSession })).toBe(false)
   })
-  it('returns true if the logged in user is a manager', () => {
+  test('returns true if the logged in user is a manager', () => {
     expect(canCreateDocumentPage({ session: testManagerSession })).toBe(true)
   })
-  it('returns false if the logged in user is a user', () => {
+  test('returns false if the logged in user is a user', () => {
     expect(canCreateDocumentPage({ session: testUserSession })).toBe(false)
   })
-  it('returns false if there is no logged in user', () => {
+  test('returns false if there is no logged in user', () => {
     expect(canCreateDocumentPage({})).toBe(false)
   })
 })

--- a/src/util/access.ts
+++ b/src/util/access.ts
@@ -126,6 +126,10 @@ export const canUpdateBookmark: OperationAccessFn = ({ session }) => {
   return session?.isAdmin || session?.role === USER_ROLES.MANAGER
 }
 
+export const canDeleteBookmark: OperationAccessFn = ({ session }) => {
+  return session?.isAdmin || session?.role === USER_ROLES.MANAGER
+}
+
 export const bookmarkCreateView: CreateViewFn = ({ session }) =>
   canCreateBookmark({ session }) ? 'edit' : 'hidden'
 


### PR DESCRIPTION
# SC-2008

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->

Allow managers and admins to delete bookmarks.

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->
You might need to set your manager's role to manager since it's not set automatically locally.

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-client
yarn dev
```

Login to the cms http://localhost:3001

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
